### PR TITLE
Update Git Repo for rpm-ostree-toolbox

### DIFF
--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -1,44 +1,7 @@
-# CentOS-Base.repo
-#
-# The mirror system uses the connecting IP address of the client and the
-# update status of each mirror to pick mirrors that are updated to and
-# geographically close to the client.  You should use this for CentOS updates
-# unless you are manually picking other mirrors.
-#
-# If the mirrorlist= does not work for you, as a fall back you can try the 
-# remarked out baseurl= line instead.
-#
-#
-
-[base]
-name=CentOS-7 - Base
+[CentOS-Base]
+name=CentOS-Base
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
 gpgcheck=1
-gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
-
-#released updates 
-[updates]
-name=CentOS-$releasever - Updates
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
-gpgcheck=1
-gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
-
-#additional packages that may be useful
-[extras]
-name=CentOS-$releasever - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
-gpgcheck=1
-gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
-
-#additional packages that extend functionality of existing packages
-[centosplus]
-name=CentOS-$releasever - Plus
-mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=centosplus&infra=$infra
-#baseurl=http://mirror.centos.org/centos/$releasever/centosplus/$basearch/
-gpgcheck=1
-enabled=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 

--- a/CentOS-updates.repo
+++ b/CentOS-updates.repo
@@ -1,0 +1,9 @@
+
+#released updates 
+[CentOS-updates]
+name=CentOS-releasever - Updates
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates&infra=$infra
+#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
+

--- a/centos-7.tdl
+++ b/centos-7.tdl
@@ -1,0 +1,14 @@
+<template>
+  <name>CentOS7</name>
+  <os>    
+    <rootpw>ozrootpw</rootpw>
+    <name>RHEL-7</name>    
+    <version>0</version>
+    <arch>x86_64</arch>
+    <install type="url">
+      <url>http://oslab-nib-vm2.openstack.engineering.redhat.com/centos/7.0.1406/os/x86_64/</url>
+    </install>
+  </os>
+  <description>RHEL7</description>
+</template>
+

--- a/centos-atomic-7.tdl
+++ b/centos-atomic-7.tdl
@@ -5,7 +5,7 @@
         <version>0</version>
         <arch>x86_64</arch>
         <install type='url'>
-            <url>https://imcleod.fedorapeople.org/centos_atomic/install-tree-test-v4/</url>
+            <url>http://buildlogs.centos.org/centos/7/atomic/x86_64/atomic-anaconda-nightly/latest/</url>
         </install>
         <rootpw>ewwwwwww</rootpw>
     </os>

--- a/centos-atomic-base.json
+++ b/centos-atomic-base.json
@@ -4,7 +4,7 @@
     "osname": "centos-atomic",
     "ref": "centos/7/atomic/x86_64/base",
     
-    "repos": ["base", "updates," "extras," "atomic7-testing", "virt7-testing"],
+    "repos": ["CentOS-Base", "CentOS-updates", "atomic7-testing", "virt7-testing"],
 
     "selinux": true,
 

--- a/centos-atomic-base.json
+++ b/centos-atomic-base.json
@@ -4,7 +4,8 @@
     "osname": "centos-atomic",
     "ref": "centos/7/atomic/x86_64/base",
     
-    "repos": ["CentOS-Base", "CentOS-updates", "atomic7-testing", "virt7-testing"],
+    "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
+              "atomic7-testing", "virt7-testing"],
 
     "selinux": true,
 

--- a/centos-atomic-host-7.ks
+++ b/centos-atomic-host-7.ks
@@ -1,0 +1,108 @@
+text
+lang en_US.UTF-8
+keyboard us
+timezone --utc Etc/UTC
+
+auth --useshadow --enablemd5
+selinux --enforcing
+rootpw --lock --iscrypted locked
+user --name=none
+
+firewall --disabled
+
+bootloader --timeout=1 --append="no_timer_check console=tty1 console=ttyS0,115200n8"
+
+network --bootproto=dhcp --device=eth0 --activate --onboot=on
+services --enabled=sshd,rsyslog,cloud-init,cloud-init-local,cloud-config,cloud-final
+# We use NetworkManager, and Avahi doesn't make much sense in the cloud
+services --disabled=network,avahi-daemon
+
+zerombr
+clearpart --all
+
+part /boot --size=300 --fstype="xfs"
+part pv.01 --grow
+volgroup atomicos pv.01
+logvol / --size=3000 --fstype="xfs" --name=root --vgname=atomicos
+
+# Equivalent of %include fedora-repo.ks
+ostreesetup --osname="@OSTREE_OSNAME@" --remote="@OSTREE_OSNAME@" --ref="@OSTREE_REF@" --url="http://@OSTREE_HOST_IP@:@OSTREE_PORT@" --nogpg
+
+reboot
+
+%post --erroronfail
+
+# Due to an anaconda bug (https://github.com/projectatomic/rpm-ostree/issues/42)
+# we need to install the repo here.
+ostree remote delete centos-atomic-host
+ostree remote add --set=gpg-verify=false centos-atomic-host 'http://buildlogs.centos.org/centos/7/atomic/x86_64/repo'
+
+# older versions of livecd-tools do not follow "rootpw --lock" line above
+# https://bugzilla.redhat.com/show_bug.cgi?id=964299
+passwd -l root
+# remove the user anaconda forces us to make
+userdel -r none
+
+# If you want to remove rsyslog and just use journald, remove this!
+echo -n "Disabling persistent journal"
+rmdir /var/log/journal/ 
+echo . 
+
+echo -n "Getty fixes"
+# although we want console output going to the serial console, we don't
+# actually have the opportunity to login there. FIX.
+# we don't really need to auto-spawn _any_ gettys.
+sed -i '/^#NAutoVTs=.*/ a\
+NAutoVTs=0' /etc/systemd/logind.conf
+
+echo -n "Network fixes"
+# initscripts don't like this file to be missing.
+cat > /etc/sysconfig/network << EOF
+NETWORKING=yes
+NOZEROCONF=yes
+EOF
+
+# For cloud images, 'eth0' _is_ the predictable device name, since
+# we don't want to be tied to specific virtual (!) hardware
+rm -f /etc/udev/rules.d/70*
+ln -s /dev/null /etc/udev/rules.d/80-net-setup-link.rules
+
+# simple eth0 config, again not hard-coded to the build hardware
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+EOF
+
+# generic localhost names
+cat > /etc/hosts << EOF
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+EOF
+echo .
+
+
+# Because memory is scarce resource in most cloud/virt environments,
+# and because this impedes forensics, we are differing from the Fedora
+# default of having /tmp on tmpfs.
+echo "Disabling tmpfs for /tmp."
+systemctl mask tmp.mount
+
+# make sure firstboot doesn't start
+echo "RUN_FIRSTBOOT=NO" > /etc/sysconfig/firstboot
+
+echo "Removing random-seed so it's not the same in every image."
+rm -f /var/lib/random-seed
+
+echo "Packages within this cloud image:"
+echo "-----------------------------------------------------------------------"
+rpm -qa
+echo "-----------------------------------------------------------------------"
+# Note that running rpm recreates the rpm db files which aren't needed/wanted
+rm -f /var/lib/rpm/__db*
+
+%end
+

--- a/centos-atomic-host-7.tdl
+++ b/centos-atomic-host-7.tdl
@@ -1,0 +1,13 @@
+<template>
+    <name>rawhide</name>
+    <os>
+        <name>RHEL-7</name>
+        <version>0</version>
+        <arch>x86_64</arch>
+        <install type='url'>
+            <url>http://oslab-nib-vm2.openstack.engineering.redhat.com/centos-atomic/install-tree-test-v2/</url>
+        </install>
+        <rootpw>ewwwwwww</rootpw>
+    </os>
+</template>
+

--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -3,13 +3,15 @@
 
     "ref": "centos/7/atomic/x86_64/cloud-docker-host",
 
+    "initramfs-args": ["--no-hostonly"],
+
     "packages": ["tuned", "man-db", "man-pages", "bash-completion",
                  "rsync", "tmux", "net-tools", "nmap-ncat", "bind-utils", "git",
                  "sysstat", "policycoreutils-python", "setools-console", "docker",
                  "audit", "cloud-init", "cloud-utils-growpart",
-                 "cockpit", "kubernetes", "etcd", "cadvisor",
-                 "centos-release-atomic"],
+                 "cockpit", "kubernetes", "etcd", "cadvisor"],
 
-    "units": ["docker.service", "cockpit.socket"]
+    "units": ["docker.service", "cockpit.socket"],
+    "default_target": "multi-user.target"
 
 }

--- a/config.ini
+++ b/config.ini
@@ -1,0 +1,59 @@
+[DEFAULT]
+
+# Where output (treecomposes, isos, and qcows) will end up. Common
+# practice would be to set to something like: 
+# /srv/rpm-ostree/%(os_name)s/%(release)s
+#outputdir   = /srv/rpm-ostree/%(os_name)s
+
+# Where tempfiles, logs, and such are stored during build.  If left blank,
+# this will default to /tmp
+# workdir     = 
+
+# Caching location for ostree trees.
+rpmostree_cache_dir = /srv/rpm-ostree/cache
+
+# The location of where the ostree repository ends up
+ostree_repo = %(outputdir)s/repo
+
+# Name applied to the composed content
+os_name     = centos-atomic-host
+
+# Same but pretty
+os_pretty_name = CentOS Atomic Host
+
+# The name of the Docker image that should be used if the installer function is
+# called.
+docker_os_name = centos:centos7
+
+# The name to apply to a set of packages.
+tree_name   = standard
+
+# Reference to the tree file which controls much of the -toolbox
+# process.  It contains repos, package lists, and much more
+tree_file   = %(os_name)s.json
+
+# Arch to be composed
+arch        = x86_64
+
+# The OS release to be used
+release     = 7
+
+# ostree uses refs to deal with content.  This defines the ref
+# name that will be used when composing.
+ref         = %(os_name)s/%(release)s/%(arch)s/%(tree_name)s
+
+# Location for JSON files, Yum repo files, kickstart , and tdl files.  The
+# path needs to be *fully qualified*.
+configdir   = 
+
+# yum_baseurl should point to the main location where yum can get its content. More
+# repos can be defined in .repo files in your configdir. An example could be:
+# http://download.fedoraproject.org/pub/fedora/linux/development/%(release)s/%(arch)s/os/
+yum_baseurl = http://mirror.centos.org/centos/%(release)s/os/%(arch)s/
+
+# Repositories above and beyond yum_baseurl that lorax can use to compose ISO content.
+# These need to be provides in a comma separated list.
+lorax_additional_repos = http://cbs.centos.org/repos/atomic7-testing/x86_64/os/ , http://mirror.centos.org/centos/%(release)s/updates/%(arch)s/
+
+[7]
+


### PR DESCRIPTION
The following changes help make rpm-ostree-toolbox be able work
with this git repository.  With -toolbox, you can create custom
atomic trees, disk images, and installer media.

    * CentOS-Base.repo
        - toolbox can only handle one repo description per file

    * CentOS-updates.repo
        - Addition of the updates repo

    * centos-7.tdl
        - generic centos7 TDL for building a utility image

    * centos-atomic-base.json
        - Added updates repo
        - corrected error for missing comma in repos list
        - remove extlinux, use grub2

    * centos-atomic-cloud-docker-host.json
        - renamed to centos-atomic-host.json which -toolbox will
          automatically detect.

    * centos-atomic-host-7.ks
        - kickstart needed by imagefactory during disk creations

    * centos-atomic-host-7.tdl
        - atomic TDL file needed by imagefactory during disk creations

    * config.ini
        - main control file needed for rpm-ostree-toolbox operations