### PR TITLE
add cloud testing repo reference

### DIFF
--- a/centos-atomic-cloud-docker-host.json
+++ b/centos-atomic-cloud-docker-host.json
@@ -3,6 +3,8 @@
 
     "ref": "centos/7/atomic/x86_64/cloud-docker-host",
 
+    "repos": ["cloud7-testing"],
+
     "packages": ["tuned", "man-db", "man-pages", "bash-completion",
                  "rsync", "tmux", "net-tools", "nmap-ncat", "bind-utils", "git",
                  "sysstat", "policycoreutils-python", "setools-console", "docker",

--- a/cloud7-testing.repo
+++ b/cloud7-testing.repo
@@ -1,0 +1,4 @@
+[cloud7-testing]
+name=cloud7-testing
+baseurl=http://cbs.centos.org/repos/cloud7-testing/x86_64/os/
+gpgcheck=0


### PR DESCRIPTION
cloud-init has grown a dependency on python-rsa which can be met
by adding a reference to the cloud repo.  Without this new repo
reference, tree composes fail.