### PR TITLE
manifest: Force initramfs to be host-independent

### DIFF
--- a/centos-atomic-base.json
+++ b/centos-atomic-base.json
@@ -8,6 +8,8 @@
 
     "selinux": true,
 
+    "initramfs-args": ["--no-hostonly"],
+
     "bootstrap_packages": ["filesystem", "glibc", "nss-altfiles", "shadow-utils",
                            "centos-release", "kernel", "rpm-ostree", "lvm2"],
 


### PR DESCRIPTION
This ensures we get xfs for example.

See https://github.com/cgwalters/rpm-ostree/commits/3a41c65c8a654837364d8d72ebf61f229dc18954