### PR TITLE
remove cloud repo reference

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -4,7 +4,6 @@
     "ref": "centos/7/atomic/x86_64/cloud-docker-host",
 
     "initramfs-args": ["--no-hostonly"],
-    "repos": ["cloud7-testing"],
 
     "packages": ["tuned", "man-db", "man-pages", "bash-completion",
                  "rsync", "tmux", "net-tools", "nmap-ncat", "bind-utils", "git",

--- a/cloud7-testing.repo
+++ b/cloud7-testing.repo
@@ -1,4 +1,0 @@
-[cloud7-testing]
-name=cloud7-testing
-baseurl=http://cbs.centos.org/repos/cloud7-testing/x86_64/os/
-gpgcheck=0


### PR DESCRIPTION
This, it turns out, was a bug.  We got a newer than desired cloud-init
package due to an error in koji tagging.  Now that we've fixed it, the
cloud repo is no longer required and should be removed to avoid
unexpectedly pulling in packages outside of our core atomic/virt tags