### PR TITLE
add development definitions in preparation for stable release

### DIFF
--- a/centos-atomic-base-devel.json
+++ b/centos-atomic-base-devel.json
@@ -1,0 +1,26 @@
+{
+    "comment": "CentOS 7 Base Atomic Development Defs",
+
+    "osname": "centos-atomic",
+    "ref": "centos/7/atomic/x86_64/base-devel",
+    
+    "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
+              "atomic7-testing", "virt7-testing"],
+
+    "selinux": true,
+
+    "initramfs-args": ["--no-hostonly"],
+
+    "bootstrap_packages": ["filesystem", "glibc", "nss-altfiles", "shadow-utils",
+                           "centos-release", "kernel", "rpm-ostree", "lvm2"],
+
+    "packages": ["syslinux-extlinux", "e2fsprogs", "xfsprogs",
+                 "selinux-policy-targeted", "audit",
+                 "openssh-server", "openssh-clients", "sudo",
+                 "passwd", "NetworkManager", "vim-minimal",
+                 "grub2", "grub2-efi", "ostree-grub2", "lvm2",
+                 "efibootmgr", "shim", "irqbalance" ],
+    
+    "default_target": "multi-user.target"
+
+}

--- a/centos-atomic-host-devel.json
+++ b/centos-atomic-host-devel.json
@@ -1,0 +1,18 @@
+{
+    "include": "centos-atomic-base-devel.json",
+
+    "ref": "centos/7/atomic/x86_64/cloud-docker-host-devel",
+
+    "initramfs-args": ["--no-hostonly"],
+
+    "packages": ["tuned", "man-db", "man-pages", "bash-completion",
+                 "rsync", "tmux", "net-tools", "nmap-ncat", "bind-utils", "git",
+                 "sysstat", "policycoreutils-python", "setools-console", "docker",
+                 "audit", "cloud-init", "cloud-utils-growpart",
+                 "cockpit", "kubernetes", "etcd", "cadvisor", "flannel",
+                 "centos-release-atomic"],
+
+    "units": ["docker.service", "cockpit.socket"],
+    "default_target": "multi-user.target"
+
+}


### PR DESCRIPTION
Ideally, once we have content in stable tags in the CBS we should
modify the "non-devel" JSON to use repos based on the content of
those tags.

For now, simply having these devel JSON files should allow us to
more confidently make day to day changes in the host definition
without worrying about breaking users attempting to atomic upgrade
on the existing released images.