### PR TITLE
virt7-testing.repo: Workaround rpm-ostree not honoring exclude= wildcard...

### DIFF
--- a/virt7-testing.repo
+++ b/virt7-testing.repo
@@ -2,4 +2,4 @@
 name=virt7-testing
 baseurl=http://cbs.centos.org/repos/virt7-testing/x86_64/os/
 gpgcheck=0
-exclude=kernel*
+exclude=kernel


### PR DESCRIPTION
...s

See https://github.com/hughsie/libhif/issues/42