### PR TITLE
repos: Disable GPG for repos; retrieving over http:// is not really usef...

### DIFF
--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -2,6 +2,6 @@
 name=CentOS-Base
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
-gpgcheck=1
+gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 

--- a/CentOS-extras.repo
+++ b/CentOS-extras.repo
@@ -2,6 +2,6 @@
 name=CentOS-$releasever - Extras
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
-gpgcheck=1
+gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 

--- a/CentOS-updates.repo
+++ b/CentOS-updates.repo
@@ -4,6 +4,6 @@
 name=CentOS-releasever - Updates
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=updates&infra=$infra
 #baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
-gpgcheck=1
+gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 


### PR DESCRIPTION
...ul

I'd expect at least CentOS to have `https://` (i.e. TLS protected)
versions of the keys available.  However if we do that it triggers
other bugs in libhif (which we'll fix), but for now let's just do
this.

See https://github.com/hughsie/libhif/issues/43