### PR TITLE
Fixes so that the Vagrant box will work properly.

### DIFF
--- a/centos-atomic-host-7-vagrant.ks
+++ b/centos-atomic-host-7-vagrant.ks
@@ -6,6 +6,7 @@
 services --disabled=cloud-init,cloud-init-local,cloud-config,cloud-final
 
 user --name=vagrant --password=vagrant
+user --name=root --password=vagrant
 
 %post --erroronfail
 


### PR DESCRIPTION
The docker changes are needed so we don't upset the docker provisioner
which expects the docker group to be present. This might not be what we
want in production because of the constant security issues in docker.