### PR TITLE
manifest: Remove cadvisor

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -9,7 +9,7 @@
                  "rsync", "tmux", "net-tools", "nmap-ncat", "bind-utils", "git",
                  "sysstat", "policycoreutils-python", "setools-console", "docker",
                  "audit", "cloud-init", "cloud-utils-growpart", "atomic", "tar",
-                 "cockpit", "kubernetes", "etcd", "cadvisor", "flannel",
+                 "cockpit", "kubernetes", "etcd", "flannel",
                  "centos-release-atomic"],
 
     "units": ["docker.service", "cockpit.socket"],


### PR DESCRIPTION
It's now obsoleted by kubernetes.