### PR TITLE
virt7-testing: Use space separated list

### DIFF
--- a/virt7-testing.repo
+++ b/virt7-testing.repo
@@ -2,4 +2,4 @@
 name=virt7-testing
 baseurl=http://cbs.centos.org/repos/virt7-testing/x86_64/os/
 gpgcheck=0
-exclude=kernel,docker
+exclude=kernel docker


### PR DESCRIPTION
This is documented in `man yum.conf`.  I'm specifically making this
change because libhif doesn't parse spaces, so we fail to do the
exclude, and thus pull in the virt7 upstream kernel, which we don't
want.