### PR TITLE
manifest: Add subscription-manager to ensure higher fidelity

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -48,6 +48,9 @@
 		 "kexec-tools",
 		 "bridge-utils",
                  "nfs-utils",
+		 "subscription-manager",
+		 "subscription-manager-plugin-ostree",
+		 "subscription-manager-plugin-container",
 		 "openssh-server", "openssh-clients",
 		 "chrony",
 		 "logrotate",
@@ -67,7 +70,8 @@
 		 "docker-storage-setup",
 		 "setools-console"],
 
-    "remove-from-packages": [["kernel", "/lib/modules/.*/drivers/gpu"],
+    "remove-from-packages": [["yum", "/usr/bin/.*"],
+			     ["kernel", "/lib/modules/.*/drivers/gpu"],
 			     ["linux-firmware", "/usr/lib/firmware/radeon/.*"],
 			     ["filesystem", "/usr/share/backgrounds"]],
 


### PR DESCRIPTION
When Ian did the original metadata export, he dropped
subscription-manager from the tree manifest, presumably under the idea
that it's not necessary for CentOS.

That's true on the face of it - but there are subtle side effects.
For example, subscription-manager presently depends on a tiny bit of
the yum Python library.

The RHELAH upstream removed `/usr/bin/yum`, but kept
`/usr/lib/python2.7/site-packages/yum` for this reason.

Now, it turns out further that some utilities like Ansible do `import yum`:
https://github.com/ansible/ansible-modules-core/blob/devel/packaging/os/yum.py

That module actually calls out to *both* `/usr/bin/yum` and directly
invokes the Python library depending on what it's doing.

But the bottom line is that due to circumstance, Ansible rules like:

```
- name: Install foo
  yum: name=foo state=present
```

Would actually work if `foo` was already installed on an Atomic host.

(Other variants like `state=updated` obviously don't).

In the interest of a higher level of fidelity (i.e. bug-for-bug
compatibility), let's restore subscription-manager, which in turn
pulls in a number of other things.

Also, if subman is installed, it might be possible to do a dynamic
rebase from a running CentOS7 host to a Red Hat Enterprise Linux
one...which would be pretty cool.