### PR TITLE
downstream: Update metadata for 7.1.2

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -15,7 +15,7 @@
 
     "documentation": false,
 
-    "initramfs-args": ["--no-hostonly"],
+    "initramfs-args": ["--no-hostonly", "--add", "iscsi"],
 
     "postprocess-script": "treecompose-post.sh",
 
@@ -26,9 +26,9 @@
     "check-passwd": { "type": "file", "filename": "passwd" },
     "check-groups": { "type": "file", "filename": "group" },
 
-    "packages": ["systemd", "kernel", "rpm-ostree-client",
-		 "atomic",
-                 "dracut-network",
+    "packages": ["atomic",
+		 "systemd", "kernel", "rpm-ostree-client",
+		 "dracut-network",
 		 "biosdevname",
 		 "coreutils",
 		 "lvm2",
@@ -38,7 +38,6 @@
 		 "mdadm",
 		 "docker",
 		 "docker-python",
-		 "docker-logrotate",
 		 "selinux-policy-targeted",
 		 "sssd",
 		 "cloud-init",
@@ -46,6 +45,7 @@
 		 "tar", "xz", "gzip", "bzip2",
 		 "less",
 		 "kexec-tools",
+		 "iscsi-initiator-utils",
 		 "bridge-utils",
                  "nfs-utils",
 		 "subscription-manager",
@@ -58,7 +58,7 @@
 		 "NetworkManager", "vim-minimal", "nano",
 		 "sudo",
 		 "tuned", "tuned-profiles-atomic",
-		 "kubernetes", "etcd", "cadvisor",
+		 "kubernetes", "etcd",
 		 "flannel",
 		 "irqbalance",
 		 "bash-completion",

--- a/group
+++ b/group
@@ -35,7 +35,7 @@ tss:x:59:
 avahi-autoipd:x:170:
 rpc:x:32:
 sssd:x:993:
-dockerroot:x:994:
+dockerroot:x:986:
 rpcuser:x:29:
 nfsnobody:x:65534:
 kube:x:994:

--- a/passwd
+++ b/passwd
@@ -18,7 +18,7 @@ tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev
 avahi-autoipd:x:170:170:Avahi IPv4LL Stack:/var/lib/avahi-autoipd:/sbin/nologin
 rpc:x:32:32:Rpcbind Daemon:/var/lib/rpcbind:/sbin/nologin
 sssd:x:995:993:User for sssd:/:/sbin/nologin
-dockerroot:x:997:996:Docker User:/var/lib/docker:/sbin/nologin
+dockerroot:x:997:986:Docker User:/var/lib/docker:/sbin/nologin
 rpcuser:x:29:29:RPC Service User:/var/lib/nfs:/sbin/nologin
 nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/sbin/nologin
 kube:x:996:994:Kubernetes user:/:/sbin/nologin


### PR DESCRIPTION
Extracted from internal, while still preserving the s/redhat/centos/
parts.