### PR TITLE
Add Continuous Release repo

### DIFF
--- a/CentOS-CR.repo
+++ b/CentOS-CR.repo
@@ -1,0 +1,28 @@
+# CentOS-CR.repo
+#
+# The Continuous Release ( CR )  repository contains rpms that are due in the next
+# release for a specific CentOS Version ( eg. next release in CentOS-7 ); these rpms
+# are far less tested, with no integration checking or update path testing having
+# taken place. They are still built from the upstream sources, but might not map 
+# to an exact upstream distro release.
+#
+# These packages are made available soon after they are built, for people willing 
+# to test their environments, provide feedback on content for the next release, and
+# for people looking for early-access to next release content.
+#
+# The CR repo is shipped in a disabled state by default; its important that users 
+# understand the implications of turning this on. 
+#
+# NOTE: We do not use a mirrorlist for the CR repos, to ensure content is available
+#       to everyone as soon as possible, and not need to wait for the external
+#       mirror network to seed first. However, many local mirrors will carry CR repos
+#       and if desired you can use one of these local mirrors by editing the baseurl
+#       line in the repo config below.
+#
+
+[cr]
+name=CentOS-7 - cr
+baseurl=http://mirror.centos.org/centos/7/cr/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0

--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -5,7 +5,7 @@
     "ref": "centos-atomic-host/7/x86_64/standard",
 
     "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
-              "rhel-atomic-rebuild"],
+              "rhel-atomic-rebuild", "cr"],
 
     "selinux": true,
 


### PR DESCRIPTION
Add continuous release repo from centos, which provides new packages a bit earlier than the standard repos, for nightly build purposes.