### PR TITLE
Remove virt7-testing repository

### DIFF
--- a/centos-atomic-base.json
+++ b/centos-atomic-base.json
@@ -5,7 +5,7 @@
     "ref": "centos/7/atomic/x86_64/base",
     
     "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
-              "atomic7-testing", "virt7-testing"],
+              "atomic7-testing"],
 
     "selinux": true,
 

--- a/virt7-testing.repo
+++ b/virt7-testing.repo
@@ -1,5 +1,0 @@
-[virt7-testing]
-name=virt7-testing
-baseurl=http://cbs.centos.org/repos/virt7-testing/x86_64/os/
-gpgcheck=0
-exclude=kernel docker


### PR DESCRIPTION
    Remove virt7-testing repo.
    
    This repo was split into many other repos, but it is not used in the
    default packages list.
