### PR TITLE
cloud/vagrant: Work around /tmp bug

### DIFF
--- a/atomic-7.1-cloud.ks
+++ b/atomic-7.1-cloud.ks
@@ -37,6 +37,9 @@ reboot
 #rm /etc/ostree/remotes.d/*.conf
 #echo 'unconfigured-state=This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.' >> $(ostree admin --print-current-dir).origin
 
+# Work around https://bugzilla.redhat.com/show_bug.cgi?id=1276775
+chmod 01777 /sysroot/tmp
+
 # Configure docker-storage-setup to resize the partition table on boot
 # https://github.com/projectatomic/docker-storage-setup/pull/25
 echo 'GROWPART=true' > /etc/sysconfig/docker-storage-setup

--- a/atomic-7.1-vagrant.ks
+++ b/atomic-7.1-vagrant.ks
@@ -36,6 +36,9 @@ reboot
 #rm /etc/ostree/remotes.d/@OSTREE_OSNAME@.conf
 #echo 'unconfigured-state=This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.' >> $(ostree admin --print-current-dir).origin
 
+# Work around https://bugzilla.redhat.com/show_bug.cgi?id=1276775
+chmod 01777 /sysroot/tmp
+
 # Anaconda is writing a /etc/resolv.conf from the generating environment.
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf


### PR DESCRIPTION
This is fixed in OSTree upstream, see
https://github.com/ostreedev/ostree/commit/7bf138b0364c8922da108e81a649bef1a5ad212b

But let's work around it here until we get the new version.
Specifically I hit this while trying to use the Vagrant box.