### PR TITLE
virt7-docker: Use https

### DIFF
--- a/virt7-docker-common-candidate.repo
+++ b/virt7-docker-common-candidate.repo
@@ -1,4 +1,4 @@
 [virt7-docker-common-candidate]
 name=virt7-docker-common-candidate
-baseurl=http://cbs.centos.org/repos/virt7-docker-common-candidate/x86_64/os/
+baseurl=https://cbs.centos.org/repos/virt7-docker-common-candidate/x86_64/os/
 gpgcheck=0


### PR DESCRIPTION
These RPMs are not GPG signed, so let's at least use `https://`
for transport integrity.