### PR TITLE
atomic-host-continuous: Merge in config that pulls in rdgo

### DIFF
--- a/atomic-centos-continuous.repo
+++ b/atomic-centos-continuous.repo
@@ -1,0 +1,3 @@
+[atomic-centos-continuous]
+baseurl=https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build
+gpgcheck=0

--- a/centos-atomic-host-continuous.json
+++ b/centos-atomic-host-continuous.json
@@ -1,0 +1,6 @@
+{
+    "include": "centos-atomic-host.json",
+    "ref": "centos-atomic-host/7/x86_64/devel/continuous",
+    "automatic_version_prefix": "2016.0",
+    "repos": ["atomic-centos-continuous"]
+}


### PR DESCRIPTION
This treefile config pulls in the continuous rdgo builds.