### PR TITLE
make treefile in build stage 1 configurable

### DIFF
--- a/build_stage1.sh
+++ b/build_stage1.sh
@@ -16,6 +16,10 @@
 
 VERSION=7.$( date  +%Y%m%d )-devel
 
+## make treefile configurable
+
+TreeFile="${TreeFile:-centos-atomic-host.json}"
+
 DateStamp=$( date  +%Y%m%d_%H%M%S )
 BuildDir=$1
 LogFile=${BuildDir}/log
@@ -64,7 +68,7 @@ ostree remote add --repo=/srv/repo centos-atomic-host --set=gpg-verify=false htt
 
 ## compose a new tree, based on defs in centos-atomic-host.json
 
-rpm-ostree compose --repo=${OstreeRepoDir} tree --add-metadata-string=version=${VERSION} ${GitDir}/centos-atomic-host.json |& tee ${BuildDir}/log.compose
+rpm-ostree compose --repo=${OstreeRepoDir} tree --add-metadata-string=version=${VERSION} ${GitDir}/${TreeFile} |& tee ${BuildDir}/log.compose
 ostree --repo=${OstreeRepoDir} summary -u |& tee ${BuildDir}/log.compose
 
 # deal with https://bugzilla.gnome.org/show_bug.cgi?id=748959


### PR DESCRIPTION
#71 merged in a new treefile to include rdgo pkgs in the devel build, but the existing treefile is hardcoded into the build script. This PR makes the treefile configurable via an env variable, with the value defaulting to the existing treefile if $TreeFile is unset.