### PR TITLE
overlay: Add oci-systemd-hook, oci-register-machine

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -35,6 +35,14 @@ components:
 
   - src: github:projectatomic/atomic-devmode
 
+  - src: github:projectatomic/oci-systemd-hook
+    distgit:
+      branch: master
+
+  - src: github:projectatomic/oci-register-machine
+    distgit:
+      branch: master
+
   - src: github:projectatomic/commissaire
     spec: internal
 


### PR DESCRIPTION
These are hooks available for use with newer versions of Docker.