### PR TITLE
ci: Explicitly build master branch

### DIFF
--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -16,6 +16,8 @@
       - git:
           url: "https://github.com/CentOS/sig-atomic-buildscripts"
           basedir: sig-atomic-buildscripts
+          branches:
+            - master
     triggers:
       - github
       - timed: "H/30 * * * *"


### PR DESCRIPTION
For some reason it was picking downstream in my job.