### PR TITLE
build: Sync full previous tree

### DIFF
--- a/build_stage1.sh
+++ b/build_stage1.sh
@@ -60,7 +60,7 @@ fi
 
 # sync repo from ds location
 
-ostree remote add --repo=/srv/repo centos-atomic-host --set=gpg-verify=false http://mirror.centos.org/centos/7/atomic/x86_64/repo && ostree pull --repo=/srv/repo --mirror centos-atomic-host centos-atomic-host/7/x86_64/standard
+ostree remote add --repo=/srv/repo centos-atomic-host --set=gpg-verify=false http://mirror.centos.org/centos/7/atomic/x86_64/repo && ostree pull --depth=-1 --repo=/srv/repo --mirror centos-atomic-host centos-atomic-host/7/x86_64/standard
 
 ## compose a new tree, based on defs in centos-atomic-host.json
 


### PR DESCRIPTION
Otherwise we may end up losing history if we `rsync --delete`.