### PR TITLE
overlay.yml: unfreeze skopeo

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -70,7 +70,6 @@ components:
       branch: master
 
   - src: github:projectatomic/skopeo
-    freeze: 026acb2a5726d6b4994ce0dfff34ccb9367b9d77
     distgit:
       branch: master
 


### PR DESCRIPTION
Fixed skopeo.spec in Fedora's dist git. Hopefully that should address the failure seen in https://github.com/projectatomic/skopeo/issues/80

@cgwalters PTAL

EDIT: not ready, i686 failures in koji...

Signed-off-by: Antonio Murdaca <runcom@redhat.com>