### PR TITLE
overlay: Add the -devel release package

### DIFF
--- a/centos-atomic-host-continuous.json
+++ b/centos-atomic-host-continuous.json
@@ -2,5 +2,6 @@
     "include": "centos-atomic-host.json",
     "ref": "centos-atomic-host/7/x86_64/devel/continuous",
     "automatic_version_prefix": "2016.0",
-    "repos": ["atomic-centos-continuous"]
+    "repos": ["atomic-centos-continuous"],
+    "packages": ["centos-devel-atomic-host-release"]
 }

--- a/overlay.yml
+++ b/overlay.yml
@@ -33,6 +33,9 @@ components:
   - distgit: go-srpm-macros
     srpmroot: true
 
+  - src: github:projectatomic/centos-release-atomic-host-devel
+    spec: internal
+
   # Keeping this around for a while to have a convenient
   # repository to test Homu/PRs etc.
   - src: github:cgwalters/playground


### PR DESCRIPTION
We really need to distinguish this from the CentOS Core, since it's
quite different.