### PR TITLE
overlay: Add backported selinux policy

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -124,3 +124,10 @@ components:
       patches: drop
 
   - distgit: kubernetes
+
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1340542
+  - src: distgit
+    disgit:
+      name: selinux-policy
+      branch: master
+      src: github:cgwalters/selinux-policy-centos-atomic-backport


### PR DESCRIPTION
```
 # ls -alZ /usr/libexec/rpm-ostreed
 -rwxr-xr-x. root root system_u:object_r:bin_t:s0       /usr/libexec/rpm-ostreed
 # nxs rebase local:
 31 metadata, 38 content objects fetched; 83813 KiB transferred in 1 seconds
 Copying /etc changes: 31 modified, 8 removed, 46 added
 Transaction complete; bootconfig swap: yes deployment count change: 0
 Freed objects: 107.9 MB
 Changed:
   selinux-policy 3.13.1-60.el7_2.3 -> 3.13.1-61.atomic.0.el7.centos
   selinux-policy-targeted 3.13.1-60.el7_2.3 -> 3.13.1-61.atomic.0.el7.centos
 # systemctl reboot
 ...
 # ls -alZ /usr/libexec/rpm-ostreed
 -rwxr-xr-x. root root system_u:object_r:install_exec_t:s0 /usr/libexec/rpm-ostreed
```