### PR TITLE
manifest: Add bubblewrap and fuse

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -64,6 +64,8 @@
 		 "tuned", "tuned-profiles-atomic",
 		 "kubernetes", "etcd",
 		 "flannel",
+		 "bubblewrap",
+		 "fuse",
 		 "irqbalance",
 		 "bash-completion",
 		 "rsync", "tmux",


### PR DESCRIPTION
These are new dependencies of rpm-ostree package layering:
https://github.com/projectatomic/rpm-ostree/pull/338

Now in practice it *would* be better for these to be added to the
fedora rpm-ostree spec file, but I don't yet want to hard depend on
these in Fedora - the implementation may change.