### PR TITLE
overlay: Unfreeze oci-systemd-hook, drop patches for skopeo

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -49,7 +49,6 @@ components:
   - src: github:projectatomic/oci-systemd-hook
     distgit:
       branch: master
-      freeze: 354b9afc28bbe1b59caca30b1435a57e459c6201
 
   - src: github:projectatomic/oci-register-machine
     distgit:
@@ -83,6 +82,7 @@ components:
   - src: github:projectatomic/skopeo
     distgit:
       branch: master
+      patches: drop
 
   - distgit: etcd
 


### PR DESCRIPTION
The dist-git gained the golang backport patch which we don't need.