### PR TITLE
atomic-centos-continuous.repo: Add a priority to ensure we override

### DIFF
--- a/atomic-centos-continuous.repo
+++ b/atomic-centos-continuous.repo
@@ -1,3 +1,4 @@
 [atomic-centos-continuous]
 baseurl=https://ci.centos.org/artifacts/sig-atomic/rdgo/centos-continuous/build
 gpgcheck=0
+priority=1


### PR DESCRIPTION
We want e.g. our skopeo whose `git describe` returns something older
than `1.9` to win out.