### PR TITLE
Drop CBS repos (virt7-docker-common-candidate and atomic7-testing)

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -5,7 +5,7 @@
     "ref": "centos-atomic-host/7/x86_64/standard",
 
     "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
-              "virt7-docker-common-candidate", "atomic7-testing",
+	      "virt7-docker-el-candidate", "atomic7-testing",
               "rhel-atomic-rebuild", "CentOS-CR"],
 
     "selinux": true,

--- a/virt7-docker-el-candidate.repo
+++ b/virt7-docker-el-candidate.repo
@@ -1,0 +1,4 @@
+[virt7-docker-el-candidate]
+name=virt7-docker-el-candidate
+baseurl=http://cbs.centos.org/repos/virt7-docker-el-candidate/x86_64/os/
+enabled=0


### PR DESCRIPTION
First, I haven't really been maintaining the atomic7 repo since manual
integration is too painful.

I'll probably put rpm-ostree into EPEL at some point instead.

We're rebuilding everything here, so let's just drop it.

Second and more notably, drop virt7-docker-common-candidate since it's
broken right now (`docker-lvm-plugin` can't be installed).

This takes us down to the docker from the Core Extras rebuild, which
isn't very exciting, but in the big picture we really want to have
more control here over the version of Docker we build, and we want to
do CI/CD bits, which Koji/CBS doesn't let us do.