### PR TITLE
overlay: Pull in a new device-mapper-persistent-data

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -130,6 +130,10 @@ components:
 
   - distgit: kubernetes
 
+  # The new thin_ls command is nice
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1228593
+  - distgit: device-mapper-persistent-data
+
   # https://bugzilla.redhat.com/show_bug.cgi?id=1340542
   - src: distgit
     distgit:


### PR DESCRIPTION
This has a new `thin_ls` command which helps users estimate space
usage.

Rebuilding the Fedora version is easy and works.