### PR TITLE
overlay: Update for micro-yuminst transition to github

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -125,7 +125,7 @@ components:
     override-version: "0.7.0"
     spec: internal
 
-  - src: https://gitlab.com/cgwalters/micro-yuminst.git
+  - src: github:cgwalters/micro-yuminst.git
     spec: internal
 
   - distgit: kubernetes


### PR DESCRIPTION
This actually breaks our CI right now because apparently gitlab just
hangs on `git fetch` after deleting a project.