### PR TITLE
add stub page for cloud provider scripts

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,31 @@
+# cloud provider scripts
+
+This directory contains scripts for producing / uploading centos atomic host images for various cloud providers.
+
+## Amazon EC2
+
+* status: We currently build and upload EC2 images, ami links at https://wiki.centos.org/SpecialInterestGroup/Atomic/Download.
+* scripts: TK
+* contact: kbsingh
+* notes:
+
+## Azure
+
+* status: TODO
+* scripts:
+* contact:
+* notes: https://github.com/Azure/azure-content/blob/master/articles/virtual-machines/virtual-machines-linux-creation-choices.md
+
+## GCE
+
+* status: TODO
+* scripts:
+* contact:
+* notes: https://cloud.google.com/compute/docs/tutorials/building-images
+
+## DigitalOcean:
+
+* status: TODO
+* scripts:
+* contact:
+* notes: https://digitalocean.uservoice.com/forums/136585-digitalocean/suggestions/5984177-project-atomic-docker-centos-fedora-scalab 


### PR DESCRIPTION
Basic info about cloud provider scripts (TK) and (mostly) TODOs.