### PR TITLE
ci: Add a lightweight 'releases' promotion system

### DIFF
--- a/centos-ci/do-release-tags
+++ b/centos-ci/do-release-tags
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# Ensure that the specified refs match a releases.yml file
+# that is stored in git.
+#
+# Copyright 2016 Colin Walters <walters@verbum.org>
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 2 of the License, or (at your option) any later version.
+# 
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#  Lesser General Public License for more details.
+# 
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+from gi.repository import GLib, Gio, OSTree
+import argparse
+import yaml
+import sys
+
+def fatal(msg):
+    print >>sys.stderr, msg
+    sys.exit(1)
+
+parser = argparse.ArgumentParser(prog=sys.argv[0])
+parser.add_argument("--repo", help="Repo path",
+                    action='store', required=True)
+parser.add_argument("--releases", help="Releases file",
+		    action='store', required=True)
+
+args = parser.parse_args()
+
+r = OSTree.Repo.new(Gio.File.new_for_path(args.repo))
+r.open(None)
+
+releasedata = yaml.load(open(args.releases))
+baseref = releasedata['baseref']
+changed = False
+for (name,commit) in releasedata['releases'].iteritems():
+    ref = baseref + name
+    [_, current] = r.resolve_rev(ref, True)
+    if current is None:
+        print("Ref {} does not currently exist".format(ref))
+    else:
+        if current == commit:
+            continue
+        print("Previously: {} = {}".format(ref, current))
+    r.set_ref_immediate(None, ref, commit)
+    print("Changed: {} = {}".format(ref, commit))
+    changed = True
+if not changed:
+    print("Processed {}: No changes".format(args.releases))

--- a/centos-ci/run-build
+++ b/centos-ci/run-build
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -xeuo pipefail
 
+dn=$(cd $(dirname $0) && pwd)
 origdir=$1
 buildscriptsdir=../sig-atomic-buildscripts
 tempdir=$(mktemp -t -d "stamp.XXXXXX")
@@ -42,6 +43,9 @@ if ! test -d ostree/repo/objects; then
     ostree --repo=ostree/repo init --mode=archive-z2
 fi
 
+# Update release tags
+$dn/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
+
 treefile=centos-atomic-host-continuous.json
 sed -i -e 's,^baseurl=.*,baseurl=file://'$(pwd)/build',' ${buildscriptsdir}/atomic-centos-continuous.repo
 sudo rpm-ostree compose tree --touch-if-changed=${tempdir}/treecompose.stamp --repo=ostree/repo ${buildscriptsdir}/${treefile}
@@ -51,5 +55,8 @@ if test -f ${tempdir}/treecompose.stamp; then
     rpm-ostree db --repo=ostree/repo diff centos-atomic-host/7/x86_64/devel/continuous{^,}
     ostree --repo=ostree/repo static-delta generate centos-atomic-host/7/x86_64/devel/continuous
     ostree --repo=ostree/repo prune --keep-younger-than='30 days ago' --refs-only
-    ostree --repo=ostree/repo summary -u
 fi
+
+# Always regenerate this right now since otherwise we have to track
+# potential changes from anything above.
+ostree --repo=ostree/repo summary -u

--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -35,6 +35,7 @@
     - mock
     - rpm-ostree
     - fedpkg
+    - PyYAML
     - rpmdistro-gitoverlay
 
 # nspawn is better, also https://lists.fedoraproject.org/pipermail/buildsys/2015-July/004833.html

--- a/releases.yml
+++ b/releases.yml
@@ -1,0 +1,8 @@
+# This file defines promoted releases from continuous -> alpha, and
+# possibly in the future from alpha -> beta.  You can think of this
+# as simply a declarative way to manage ostree commits.  See `do-release-tags`.
+
+baseref: "centos-atomic-host/7/x86_64/devel/"
+
+releases:
+  alpha: 04d5efc4e069bcb38c6d847835a6af98299b17388c1a49838e917dae11b262c4


### PR DESCRIPTION
Add a `releases.yml` file which is a delarative way to do
"ostree tags".  This adds a first release for an `alpha` branch.

In the future I plan to add image generation to this.