### PR TITLE
ci: Dedup code in jobs

### DIFF
--- a/centos-ci/jjb/sig-atomic-defaults.yml
+++ b/centos-ci/jjb/sig-atomic-defaults.yml
@@ -2,10 +2,15 @@
     name: atomic-defaults
     node: atomic-sig-ci-slave01 
     quiet-period: 0
+    description: |
+      <p>See <a href="https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel">https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel</a>
+         for more information.</p>
     wrappers:
       - ansicolor
       - workspace-cleanup
       - timestamps
+    scm:
+      - atomic-scms
 
 - scm:
     name: atomic-scms

--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -1,17 +1,5 @@
-- job:
-    name: atomic-rdgo-centos7
-    node: atomic-sig-ci-slave01 
-    description: |
-      <p>See <a href="https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel">https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel</a>
-         for more information.</p>
-    scm:
-      - atomic-scms
-    triggers:
-      - github
-      - timed: "H/30 * * * *"
-
-    defaults: atomic-defaults
-
+- builder:
+    name: atomic-duffy-builder
     builders:
       - macro-cciskel-duffy-prepared-allocate:
           jobclass: builder
@@ -22,64 +10,93 @@
           set -xeuo pipefail
 
           (echo -n "export RSYNC_PASSWORD=" && cat ~/duffy.key | cut -c '-13') > rsync-password.sh
+          cat >>task.env <<EOF
+          export JENKINS_JOB_NAME="${{JOB_NAME}}"
+          export JENKINS_BUILD_TAG="${{BUILD_TAG}}"
+          EOF
+          cat task.env
 
-          rsync -Hrlptv --stats -e ssh sig-atomic-buildscripts rsync-password.sh builder@${DUFFY_HOST}:
+          rsync -Hrlptv --stats -e ssh task.env sig-atomic-buildscripts rsync-password.sh builder@${{DUFFY_HOST}}:
           build_success=true
-          if ! ssh -tt builder@${DUFFY_HOST} ./sig-atomic-buildscripts/centos-ci/run-rdgo-rsync; then
+          if ! ssh -tt builder@${{DUFFY_HOST}} '. task.env && ./sig-atomic-buildscripts/centos-ci/{task}'; then
             build_success=false
           fi
-          rsync -Hrlptv --stats -e ssh builder@${DUFFY_HOST}:build-logs $WORKSPACE/build-logs || true
+          rsync -Hrlptv --stats -e ssh builder@${{DUFFY_HOST}}:build-logs $WORKSPACE/build-logs || true
           # Exit with code from the build
-          if test "${build_success}" = "false"; then
+          if test "${{build_success}}" = "false"; then
             echo 'Build failed, see logs above'; exit 1
           fi
-            
+
+- publisher:
+    name: atomic-duffy-publisher
     publishers:
       - archive:
           artifacts: 'build-logs/**'
           allow-empty: 'true'
+      - macro-cciskel-duffy-deallocate
+
+- publisher:
+    name: atomic-trigger-on-change
+    publishers:
       - conditional-publisher:
           - condition-kind: file-exists
-            condition-filename: build-logs/build.stamp
+            condition-filename: build-logs/changed.stamp
             condition-basedir: workspace
             action:
               - trigger:
-                  project: 'atomic-treecompose-centos7'
+                  project: "{project}"
 
-      - macro-cciskel-duffy-deallocate
+- job:
+    name: atomic-rdgo-centos7
+    defaults: atomic-defaults
+    triggers:
+      - github
+      - timed: "H/30 * * * *"
 
-- job-template:
-    name: 'atomic-{task}-centos7'
-    node: atomic-sig-ci-slave01 
-    description: |
-      <p>See <a href="https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel">https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel</a>
-         for more information.</p>
-    scm:
-      - atomic-scms
+    builders:
+      - atomic-duffy-builder:
+          task: run-rdgo-rsync
+            
+    publishers:
+      - atomic-trigger-on-change:
+          project: 'atomic-treecompose-centos7'
+      - atomic-duffy-publisher
+
+- job:
+    name: 'atomic-treecompose-centos7'
+    defaults: atomic-defaults
     triggers:
       - github
       - timed: "H * * * *"
 
-    defaults: atomic-defaults
-
     builders:
-      - macro-cciskel-duffy-prepared-allocate:
-          jobclass: builder
-          duffytimeoutsecs: 3600
-          playbook: sig-atomic-buildscripts/centos-ci/setup/setup-system.yml
-      - shell: |
-          #!/bin/bash
-          set -xeuo pipefail
-          (echo -n "export RSYNC_PASSWORD=" && cat ~/duffy.key | cut -c '-13') > rsync-password.sh
-          rsync -Hrlptv --stats -e ssh sig-atomic-buildscripts rsync-password.sh builder@${{DUFFY_HOST}}:
-          ssh -tt builder@${{DUFFY_HOST}} ./sig-atomic-buildscripts/centos-ci/run-{task}
+      - atomic-duffy-builder:
+          task: run-treecompose
             
     publishers:
-      - macro-cciskel-duffy-deallocate
+      - atomic-trigger-on-change:
+          project: 'atomic-installer-centos7'
+      - atomic-trigger-on-change:
+          project: 'atomic-image-cloud-centos7'
+      - atomic-duffy-publisher
+
+- job-template:
+    name: 'atomic-{imagetask}-centos7'
+    defaults: atomic-defaults
+    triggers:
+      - github
+      - timed: "H H/4 * * *"
+
+    builders:
+      - atomic-duffy-builder:
+          task: run-{imagetask}
+            
+    publishers:
+      - atomic-duffy-publisher
 
 - job:
     name: atomic-dockerimage-centosmin
-    node: atomic-sig-ci-slave01 
+    defaults: atomic-defaults
     description: |
       <p>This job builds <a href="https://github.com/cgwalters/centos-dockerbase-minimal">https://github.com/cgwalters/centos-dockerbase-minimal</a></p>
     scm:
@@ -93,8 +110,6 @@
     triggers:
       - github
       - timed: "H/30 * * * *"
-
-    defaults: atomic-defaults
 
     builders:
       - macro-cciskel-duffy-prepared-allocate:
@@ -127,14 +142,13 @@
           allow-empty: 'true'
       - macro-cciskel-duffy-deallocate
 
-# create the jobs using the job templates
 - project:
     name: atomic-rdgo
-    task:
-      - treecompose
+    imagetask:
       - installer
       - image-cloud
-#      - image-pxelive  # disabled for now pending debugging
+      - image-pxelive
     jobs:
       - atomic-rdgo-centos7
-      - 'atomic-{task}-centos7'
+      - atomic-treecompose-centos7
+      - atomic-{imagetask}-centos7

--- a/centos-ci/libtask.sh
+++ b/centos-ci/libtask.sh
@@ -1,0 +1,33 @@
+buildscriptsdir=$(cd ~/sig-atomic-buildscripts && pwd)
+build=centos-continuous
+ref=centos-atomic-host/7/x86_64/devel/continuous
+
+prepare_job() {
+    export WORKSPACE=$HOME/jobs/${JENKINS_JOB_NAME}
+    rm ${WORKSPACE} -rf
+    mkdir -p ${WORKSPACE}
+
+    export CACHEDIR=$HOME/cache
+    mkdir -p ${CACHEDIR}
+
+    export BUILD_LOGS=$HOME/build-logs
+    rm ${BUILD_LOGS} -rf
+    mkdir ${BUILD_LOGS}
+
+    . ~/rsync-password.sh 
+
+    # Ensure we're operating on a clean base
+    (cd ${buildscriptsdir} && git clean -dfx && git reset --hard HEAD)
+
+    # Work around https://lists.centos.org/pipermail/ci-users/2016-July/000302.html
+    for file in config.ini atomic-centos-continuous.repo cahc.tdl cloud.ks vagrant.ks pxelive.ks; do
+	sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' ${buildscriptsdir}/${file}
+    done
+
+    cd ${WORKSPACE}
+}
+
+# Avoid recursion
+if test -z "${WORKSPACE:-}"; then
+    prepare_job
+fi

--- a/centos-ci/libtoolbox.sh
+++ b/centos-ci/libtoolbox.sh
@@ -24,13 +24,6 @@ prepare_image_build() {
 	exit 0
     fi
 
-    # Ensure we're operating on a clean base
-    (cd ${buildscriptsdir} && git clean -dfx && git reset --hard HEAD)
-    # Work around https://lists.centos.org/pipermail/ci-users/2016-July/000302.html
-    for file in config.ini atomic-centos-continuous.repo cahc.tdl cloud.ks vagrant.ks pxelive.ks; do
-	sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' ${buildscriptsdir}/${file}
-    done
-
     cd images/${imgtype}
 }
 

--- a/centos-ci/run-image-cloud
+++ b/centos-ci/run-image-cloud
@@ -1,12 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 basedir=$(cd $(dirname $0) && pwd)
-build=centos-continuous
-buildscriptsdir=$(cd sig-atomic-buildscripts && pwd)
-ref=centos-atomic-host/7/x86_64/devel/continuous
-
+. ${basedir}/libtask.sh
 . ${basedir}/libtoolbox.sh
-. ~/rsync-password.sh 
 
 prepare_image_build cloud
 # FIXME - use ISO content rather than KS

--- a/centos-ci/run-image-pxelive
+++ b/centos-ci/run-image-pxelive
@@ -1,12 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 basedir=$(cd $(dirname $0) && pwd)
-build=centos-continuous
-buildscriptsdir=$(cd sig-atomic-buildscripts && pwd)
-ref=centos-atomic-host/7/x86_64/devel/continuous
-
+. ${basedir}/libtask.sh
 . ${basedir}/libtoolbox.sh
-. ~/rsync-password.sh 
 
 prepare_image_build pxelive
 sudo rpm-ostree-toolbox liveimage ${toolbox_base_args} --preserve-ks-url \

--- a/centos-ci/run-installer
+++ b/centos-ci/run-installer
@@ -1,12 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 basedir=$(cd $(dirname $0) && pwd)
-build=centos-continuous
-buildscriptsdir=$(cd sig-atomic-buildscripts && pwd)
-ref=centos-atomic-host/7/x86_64/devel/continuous
-
+. ${basedir}/libtask.sh
 . ${basedir}/libtoolbox.sh
-. ~/rsync-password.sh 
 
 prepare_image_build installer
 sudo rpm-ostree-toolbox installer ${toolbox_base_args} -o ${version} --overwrite

--- a/centos-ci/run-rdgo
+++ b/centos-ci/run-rdgo
@@ -1,26 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 
-dn=$(cd $(dirname $0) && pwd)
-origdir=$1
-buildscriptsdir=$(cd ../sig-atomic-buildscripts && pwd)
-tempdir=$(mktemp -t -d "stamp.XXXXXX")
-touch ${tempdir}/.testtmp
-function cleanup () {
-    if test -n "${TEST_SKIP_CLEANUP:-}"; then
-	echo "Skipping cleanup of ${tempdir}"
-    else if test -f ${tempdir}/.testtmp; then
-	rm "${tempdir}" -rf
-    fi
-    fi
-}
-trap cleanup EXIT
-
-# Ensure we're operating on a clean base
-(cd ${buildscriptsdir} && git clean -dfx && git reset --hard HEAD)
-
-# Create this now so it always exists for Jenkins
-mkdir -p ${origdir}/build-logs
+basedir=$(cd $(dirname $0) && pwd)
+. ${basedir}/libtask.sh
 
 cd rdgo
 ln -sf ${buildscriptsdir}/overlay.yml .
@@ -29,9 +11,6 @@ if ! test -d src; then
 fi    
 
 # Git fetch all the things
-rpmdistro-gitoverlay resolve --fetch-all --touch-if-changed ${tempdir}/fetch.stamp
-
-# Do an RPM build if something changed
-if test -f ${tempdir}/fetch.stamp; then
-    rpmdistro-gitoverlay build --touch-if-changed ${origdir}/build-logs/build.stamp --logdir=${origdir}/build-logs
-fi
+rpmdistro-gitoverlay resolve --fetch-all
+# Do a build
+rpmdistro-gitoverlay build --touch-if-changed ${BUILD_LOGS}/build.stamp --logdir=${BUILD_LOGS}

--- a/centos-ci/run-rdgo-rsync
+++ b/centos-ci/run-rdgo-rsync
@@ -2,26 +2,21 @@
 set -xeuo pipefail
 
 basedir=$(cd $(dirname $0) && pwd)
+. ${basedir}/libtask.sh
 
-. ~/rsync-password.sh 
-
-build=centos-continuous
-
-mkdir -p ${build}
-origdir=$(pwd)
-cd ${build}
 for v in rdgo; do
     rsync --delete --stats -a sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/ ${v}/
 done
 
 build_success=false
-if ${basedir}/run-rdgo ${origdir}; then
+if ${basedir}/run-rdgo; then
     build_success=true
 fi
 
 for v in rdgo; do
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done
+
 if test "${build_success}" = false; then
     echo "Build failed, see logs above"; exit 1
 fi

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -1,36 +1,12 @@
 #!/bin/bash
 set -xeuo pipefail
 basedir=$(cd $(dirname $0) && pwd)
-origdir=$(pwd)
-build=centos-continuous
-buildscriptsdir=$(cd sig-atomic-buildscripts && pwd)
-tempdir=$(mktemp -t -d "stamp.XXXXXX")
-touch ${tempdir}/.testtmp
-function cleanup () {
-    if test -n "${TEST_SKIP_CLEANUP:-}"; then
-	echo "Skipping cleanup of ${tempdir}"
-    else if test -f ${tempdir}/.testtmp; then
-	rm "${tempdir}" -rf
-    fi
-    fi
-}
-trap cleanup EXIT
+. ${basedir}/libtask.sh
+. ${basedir}/libtoolbox.sh
 
-. ~/rsync-password.sh 
-
-mkdir -p ${build}
-cd ${build}
 for v in ostree; do
     rsync --delete --stats -a sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/ ${v}/
 done
-
-# Ensure we're operating on a clean base
-(cd ${buildscriptsdir} && git clean -dfx && git reset --hard HEAD)
-
-if ! test -d ostree/repo/objects; then
-    mkdir -p ostree/repo
-    ostree --repo=ostree/repo init --mode=archive-z2
-fi
 
 # Update release tags
 $basedir/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
@@ -38,8 +14,8 @@ $basedir/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releas
 treefile=centos-atomic-host-continuous.json
 # Work around https://lists.centos.org/pipermail/ci-users/2016-July/000302.html
 sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' ${buildscriptsdir}/atomic-centos-continuous.repo
-sudo rpm-ostree compose tree --touch-if-changed=${tempdir}/treecompose.stamp --repo=ostree/repo ${buildscriptsdir}/${treefile}
-if test -f ${tempdir}/treecompose.stamp; then
+sudo rpm-ostree compose tree --touch-if-changed=${WORKSPACE}/treecompose.stamp --repo=ostree/repo ${buildscriptsdir}/${treefile}
+if test -f ${WORKSPACE}/treecompose.stamp; then
     sudo chown -R -h $USER:$USER ostree/repo
     ostree --repo=ostree/repo summary -u
     rpm-ostree db --repo=ostree/repo diff centos-atomic-host/7/x86_64/devel/continuous{^,}


### PR DESCRIPTION
Make the "execute script on Duffy node, gathering build logs" a
generic model that's used for everything.  This way we can more
cleanly have logs for failed installer builds for example (not
implemented yet).

Introduce a mechanism to propagate selected environment variables from
Jenkins to the node, which means that the tasks can reference
`$WORKSPACE` as a scratch area.  In the future I plan to also have
things like `${ref}` be parameterized, so that it's easier to
introduce image builds for stable tags.