### PR TITLE
releases: Update to alpha 2016.0.202

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -5,4 +5,5 @@
 baseref: "centos-atomic-host/7/x86_64/devel/"
 
 releases:
-  alpha: 04d5efc4e069bcb38c6d847835a6af98299b17388c1a49838e917dae11b262c4
+  # Version: 2016.0.202 (2016-07-28 15:30:03)
+  alpha: 59ba6b05b53c53df47e7c043d37f6d68ef643fc6a23c091797e6a7de707bce90


### PR DESCRIPTION
There are a number of changes, but the most important one is that we
pick up the addition of the remotes to the `-release` package, which
makes the alpha media installation have out-of-the-box upgrades.

(I didn't test the release process itself, let's see...)