### PR TITLE
overlay: Backport newer xfsprogs

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -86,6 +86,9 @@ components:
       branch: master
       patches: drop
 
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8
+  - distgit: xfsprogs
+
   - distgit: etcd
 
   - src: gnome:libgsystem


### PR DESCRIPTION
This is needed for newer d_type by default, which will fix overlayfs.
https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8