### PR TITLE
main: Ensure we pull latest ostree + glib2

### DIFF
--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -43,6 +43,8 @@
     - rsync
     - mock
     - libsolv
+    - glib2
+    - ostree
     - rpm-ostree
     - rpm-ostree-toolbox
     - fedpkg


### PR DESCRIPTION
Unfortunately glib2's lack of versioned symbols means we may hit
issues with `g_file_enumerator_iterate()` unless we update it.  Might
as well ensure ostree is updated too.

Really we should update everything...or switch to containers...but
for now, this.