### PR TITLE
overlay: Bind runc with Fedora's version

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -89,6 +89,8 @@ components:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8
   - distgit: xfsprogs
 
+  - distgit: runc
+
   - distgit: etcd
 
   - src: gnome:libgsystem


### PR DESCRIPTION
While runc isn't 1.0 yet, we might as well ensure we're version
locked with Fedora.