### PR TITLE
manifest: Use 7. before version, drop 0, add mutate-os-release

### DIFF
--- a/centos-atomic-host-continuous.json
+++ b/centos-atomic-host-continuous.json
@@ -1,7 +1,8 @@
 {
     "include": "centos-atomic-host.json",
     "ref": "centos-atomic-host/7/x86_64/devel/continuous",
-    "automatic_version_prefix": "2016.0",
+    "automatic_version_prefix": "7.2016",
+    "mutate-os-release": "7",
     "repos": ["atomic-centos-continuous"],
     "packages": ["centos-devel-atomic-host-release"]
 }


### PR DESCRIPTION
The version starting with `2016.` is rather uninformative, let's
switch to starting with `7.` being the major.  Also the intermediate
`0.` is pointless, so kill it.

Finally, use the new `mutate-os-release` field to ensure the
ostree version ends up in `/etc/os-release`.