### PR TITLE
overlay: Bump runc to v1.0pre

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -89,7 +89,10 @@ components:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8
   - distgit: xfsprogs
 
-  - distgit: runc
+  - src: github:opencontainers/runc
+    tag: v1.0.0-rc1
+    distgit:
+      branch: master
 
   - distgit: etcd
 


### PR DESCRIPTION
We want to use it in system containers.