### PR TITLE
ci: Rework alpha to be based on recommit promotion

### DIFF
--- a/centos-ci/do-release-tags
+++ b/centos-ci/do-release-tags
@@ -28,6 +28,8 @@ def fatal(msg):
     sys.exit(1)
 
 parser = argparse.ArgumentParser(prog=sys.argv[0])
+parser.add_argument("--ignore-no-previous-promotion", help="Releases file",
+		    action='store_true')
 parser.add_argument("--repo", help="Repo path",
                     action='store', required=True)
 parser.add_argument("--releases", help="Releases file",
@@ -41,17 +43,46 @@ r.open(None)
 releasedata = yaml.load(open(args.releases))
 baseref = releasedata['baseref']
 changed = False
-for (name,commit) in releasedata['releases'].iteritems():
+for (name,newcommit) in releasedata['releases'].iteritems():
     ref = baseref + name
     [_, current] = r.resolve_rev(ref, True)
     if current is None:
         print("Ref {} does not currently exist".format(ref))
     else:
-        if current == commit:
-            continue
-        print("Previously: {} = {}".format(ref, current))
-    r.set_ref_immediate(None, ref, commit)
-    print("Changed: {} = {}".format(ref, commit))
+        _,currentcommitdata,_ = r.load_commit(current)
+        currentcommitmeta = currentcommitdata.get_child_value(0)
+        currentpromotedv = currentcommitmeta.lookup_value("promotion-of", GLib.VariantType.new("s"))
+        if currentpromotedv is None:
+            msg = "Missing promotion-of metadata key in {}".format(current)
+            if args.ignore_no_previous_promotion:
+                print("warning: " + msg)
+                currentpromoted = '(missing)'
+                newparent = None
+            else:
+                fatal(msg)
+        else:
+            currentpromoted = currentpromotedv.get_string()
+            newparent = current
+            if currentpromoted == newcommit:
+                print("No changes in {} = {}, promoted from {}".format(ref, current, currentpromoted))
+                continue
+        print("Previously: {} = {}, promoted from {}".format(ref, current, currentpromoted))
+    _,newcommitdata,_ = r.load_commit(newcommit)
+    _,newcommitroot,_ = r.read_commit(newcommit, None)
+    newcommitmeta = newcommitdata.get_child_value(0)
+    versionv = newcommitmeta.lookup_value("version", GLib.VariantType.new("s"))
+    if versionv:
+        version = versionv.get_string()
+
+    promotedmetadict = GLib.VariantDict.new(newcommitmeta)
+    promotedmetadict.insert_value("promotion-of", GLib.Variant.new_string(newcommit))
+    body = 'PromotionOf: {}'.format(newcommit)
+
+    mtree = OSTree.MutableTree.new()
+    _,promotedcommit = r.write_commit(newparent, '', body, promotedmetadict.end(), newcommitroot, None)
+    r.set_ref_immediate(None, ref, promotedcommit)
+    if version:
+        print "Promoted commit {} (version {}) => {}".format(newcommit, version, promotedcommit)
     changed = True
 if not changed:
     print("Processed {}: No changes".format(args.releases))

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -9,9 +9,11 @@ for v in ostree; do
 done
 
 # Update release tags
-$basedir/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
-# Need to generate a delta from the previous tagged commit
-ostree --repo=ostree/repo static-delta generate -n --from=04d5efc4e069bcb38c6d847835a6af98299b17388c1a49838e917dae11b262c4 --to=centos-atomic-host/7/x86_64/devel/alpha
+$basedir/do-release-tags --ignore-no-previous-promotion --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
+# Ensure we have a delta from the previous alpha
+ostree --repo=ostree/repo static-delta generate -n --from=59ba6b05b53c53df47e7c043d37f6d68ef643fc6a23c091797e6a7de707bce90 --to=centos-atomic-host/7/x86_64/devel/alpha
+# Now, ensure we have a delta from N-1 -> N
+ostree --repo=ostree/repo static-delta generate -n centos-atomic-host/7/x86_64/devel/alpha
 
 treefile=centos-atomic-host-continuous.json
 # Work around https://lists.centos.org/pipermail/ci-users/2016-July/000302.html

--- a/releases.yml
+++ b/releases.yml
@@ -7,5 +7,5 @@ baseref: "centos-atomic-host/7/x86_64/devel/"
 # Procedure: When performing an update, be sure to change
 # the previous release commit id in run-treecompose too.
 releases:
-  # Version: 2016.0.202 (2016-07-28 15:30:03)
-  alpha: 59ba6b05b53c53df47e7c043d37f6d68ef643fc6a23c091797e6a7de707bce90
+  # Version: 7.2016.106 (2016-08-26 13:12:14)
+  alpha: 06ec5b13641f16279b09ac17c46b158f85e4d58c5954eeda4f2803ca28b4ae93


### PR DESCRIPTION
Previously, we were doing promotion based on updates to the branch
ref.  The problem with this is that we don't have in-repo knowledge of
the history of the target `alpha`. branch.  Things like `ostree log`
show the `continuous` branch.  And in particular, if we want to
generate static deltas between the promoted alpha commits, we'd have
to maintain a branch history of alpha.

So this reworks things to create a new commit, but with the *same
binary content* as the origin commit.  We add metadata `promotion-of`
into the alpha commits that allow us to trace the origin state, and
allows this tool in particular to implement idempotency.

This in turn will allow us to just blindly invoke `ostree static-delta
generate .../alpha` and have it work.

Closes: https://github.com/CentOS/sig-atomic-buildscripts/issues/137