### PR TITLE
cloud.ks: Ensure root has a default bash prompt

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -35,6 +35,9 @@ reboot
 # https://github.com/projectatomic/docker-storage-setup/pull/25
 echo 'GROWPART=true' > /etc/sysconfig/docker-storage-setup
 
+# Work around https://bugzilla.redhat.com/show_bug.cgi?id=1193590
+cp /etc/skel/.bash* /var/roothome
+
 # Anaconda is writing a /etc/resolv.conf from the generating environment.
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf


### PR DESCRIPTION
Various discussion in https://bugzilla.redhat.com/show_bug.cgi?id=1193590
but it's easiest to stop waiting and just add the one liner hack.

This isn't a *complete* fix because:

1) This doesn't apply to ISO installs
2) It is an annoying bit of trivium that everyone else using rpm-ostree
   will have to carry in their kickstarts