### PR TITLE
overlay: Rebuild cockpit from Fedora

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -113,6 +113,8 @@ components:
       branch: master
       patches: drop
 
+  - distgit: cockpit
+
   # Maybe in the future track libsolv git master, but it's not something
   # we actively hack on.
   - src: distgit


### PR DESCRIPTION
The goal here is that we version lock Fedora with CentOSDev, so
we can perform simultaneous integration testing.