### PR TITLE
Revert "overlay: Rebuild cockpit from Fedora"

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -113,8 +113,6 @@ components:
       branch: master
       patches: drop
 
-  - distgit: cockpit
-
   # Maybe in the future track libsolv git master, but it's not something
   # we actively hack on.
   - src: distgit


### PR DESCRIPTION
This reverts commit 6eec6da3abe63feefe718819b391a142079616f9.

It fails `%check` with `--new-chroot`.

```
<petervo> they all look related to cockpit not able to find a inet device to listen on
<walters> petervo, mock --new-chroot which is nspawn
<walters> with --private-network which is just loopback
<petervo> yeah, that's why
```