### PR TITLE
overlay: track skopeo signing work

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -79,10 +79,12 @@ components:
   # A lot of the signing work is happening in this repo/branch and it is
   # needed to keep the atomic CLI working
   - src: github:mtrmac/skopeo
+    branch: integrate-all-the-things
     # repo priorities aren't wired up in libhif right now
     override-version: "1.14"
     distgit:
-      branch: integrate-all-the-things
+      branch: master
+      patches: drop
 
   # https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8
   - distgit: xfsprogs

--- a/overlay.yml
+++ b/overlay.yml
@@ -76,12 +76,13 @@ components:
     distgit:
       branch: master
 
-  - src: github:projectatomic/skopeo
+  # A lot of the signing work is happening in this repo/branch and it is
+  # needed to keep the atomic CLI working
+  - src: github:mtrmac/skopeo
     # repo priorities aren't wired up in libhif right now
-    override-version: "1.10"
+    override-version: "1.14"
     distgit:
-      branch: master
-      patches: drop
+      branch: integrate-all-the-things
 
   # https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8
   - distgit: xfsprogs


### PR DESCRIPTION
Our internal CI running against CAHC caught projectatomic/atomic#648
and it seems that part of the fix is going to require a version of
skopeo that is in the @mtrmac repo/branch.

This change (hopefully) changes CAHC to track that version of skopeo.