### PR TITLE
Exclude skopeo from CentOS extras to ensure we get it from rdgo

### DIFF
--- a/CentOS-extras.repo
+++ b/CentOS-extras.repo
@@ -6,4 +6,4 @@ gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 # List excludes here that have higher versions in extras, until we implement
 # priorities: https://github.com/CentOS/sig-atomic-buildscripts/issues/138
-exclude=cloud-utils-growpart atomic
+exclude=cloud-utils-growpart atomic skopeo


### PR DESCRIPTION
Followup to https://github.com/CentOS/sig-atomic-buildscripts/pull/155