### PR TITLE
Exclude skopeo from virt7-docker

### DIFF
--- a/virt7-docker-el-candidate.repo
+++ b/virt7-docker-el-candidate.repo
@@ -3,3 +3,6 @@ name=virt7-docker-el-candidate
 baseurl=http://cbs.centos.org/repos/virt7-docker-el-candidate/x86_64/os/
 enabled=0
 gpgcheck=0
+# We want skopeo built from the git repo, so exclude it here and in
+# CentOS-Extras
+exclude=skopeo


### PR DESCRIPTION
It was excluded from CentOS-Extras in #157, but then it got pulled
from virt7-docker-el-candidate.  So exclude it there, too.

Another follow-up to #155