### PR TITLE
manifest: add dracut-fips to enable FIPS mode

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -80,7 +80,8 @@
 		 "docker-novolume-plugin",
                  "stub-redhat-lsb-core-only-for-ceph",
                  "ceph-common", "device-mapper-multipath",
-                 "sg3_utils", "glusterfs-fuse"],
+                 "sg3_utils", "glusterfs-fuse",
+                 "dracut-fips"],
 
     "remove-from-packages": [["yum", "/usr/bin/.*"],
 			     ["kernel", "/lib/modules/.*/drivers/gpu"],


### PR DESCRIPTION
This package contains the FIPS dracut module, which is required for AH
to properly function when booted in FIPS mode.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1377226