### PR TITLE
manifest: explicitly include attr package

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -80,7 +80,8 @@
 		 "setools-console",
                  "device-mapper-multipath",
                  "sg3_utils",
-                 "dracut-fips"],
+                 "dracut-fips",
+                 "attr"],
 
     "remove-from-packages": [["yum", "/usr/bin/.*"],
 			     ["kernel", "/lib/modules/.*/drivers/gpu"],


### PR DESCRIPTION
The 'attr' package was getting pulled in by the 'glusterfs-fuse'
package in Centos Atomic Host.  Because CAHC has dropped that from the
package list, we lost the package and the ability to use `getfattr` in
the [atomic-host-tests.](https://github.com/projectatomic/atomic-host-tests)