### PR TITLE
Revert "manifest: add dracut-fips to enable FIPS mode (#160)"

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -80,7 +80,6 @@
 		 "setools-console",
                  "device-mapper-multipath",
                  "sg3_utils",
-                 "dracut-fips",
                  "attr"],
 
     "remove-from-packages": [["yum", "/usr/bin/.*"],


### PR DESCRIPTION
This reverts commit a383b9c794c53c2fc616bcf91df5a193bfc65f36.