### PR TITLE
treecompose: Drop legacy code paths for previous alpha model

### DIFF
--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -9,9 +9,7 @@ for v in ostree; do
 done
 
 # Update release tags
-$basedir/do-release-tags --ignore-no-previous-promotion --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
-# Ensure we have a delta from the previous alpha
-ostree --repo=ostree/repo static-delta generate -n --from=59ba6b05b53c53df47e7c043d37f6d68ef643fc6a23c091797e6a7de707bce90 --to=centos-atomic-host/7/x86_64/devel/alpha
+$basedir/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
 # Now, ensure we have a delta from N-1 -> N
 if ostree --repo=ostree/repo rev-parse centos-atomic-host/7/x86_64/devel/alpha^ 2>/dev/null; then
     ostree --repo=ostree/repo static-delta generate -n centos-atomic-host/7/x86_64/devel/alpha


### PR DESCRIPTION
Things actually break now since apparently we gc'd the old
alpha commits :/

Anyways, we don't need the `--ignore-no-previous-promotion`, and
we can now reliably use `^` to refer to the previous ref.