### PR TITLE
overlay.yml: add dracut and cpio with --reproducible

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -152,3 +152,11 @@ components:
       name: selinux-policy
       branch: master
       src: github:cgwalters/selinux-policy-centos-atomic-backport
+
+  - distgit: cpio
+
+  - src: distgit
+    distgit:
+      name: dracut
+      branch: master
+      src: github:giuseppe/dracut-cahc-distgit


### PR DESCRIPTION
Add a version of dracut and cpio that have --reproducible so that the
initramfs doesn't change on each commit.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>