### PR TITLE
vagrant.ks: set up rootpw like downstream

### DIFF
--- a/vagrant.ks
+++ b/vagrant.ks
@@ -5,6 +5,7 @@
 
 services --disabled=cloud-init,cloud-init-local,cloud-config,cloud-final
 
+rootpw vagrant
 user --name=vagrant --password=vagrant
 
 %post --erroronfail


### PR DESCRIPTION
Right now, in the downstream box, we're able to use
config.ssh.username = 'root'
to tell Vagrant to directly ssh into root. This is great when e.g.
scripting things that assume root access without having to pepper sudo
everywhere.

Let's be consistent and do the same here so that they can be used
interchangeably in a Vagrantfile.