### PR TITLE
vagrant.ks: also make sure the root account is unlocked

### DIFF
--- a/vagrant.ks
+++ b/vagrant.ks
@@ -10,6 +10,10 @@ user --name=vagrant --password=vagrant
 
 %post --erroronfail
 
+# The inherited cloud %post locks the passwd, but we want it
+# unlocked for vagrant, just like downstream.
+passwd -u root
+
 # Work around cloud-init being both disabled and enabled; need
 # to refactor to a common base.
 rm /etc/systemd/system/multi-user.target.wants/cloud-init* /etc/systemd/system/multi-user.target.wants/cloud-config*


### PR DESCRIPTION
As a follow-up to 909489b, we also need to explicitly unlock the root
account in %post, to undo the locking done in the inherited cloud
kickstart. In downstream, this is not an issue because the vagrant
kickstart does not inherit from the cloud kickstart.