### PR TITLE
Sync metadata with downstream

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -16,6 +16,7 @@
 
     "initramfs-args": ["--no-hostonly", "--add", "iscsi"],
 
+    "mutate-os-release": "7",
     "postprocess-script": "treecompose-post.sh",
 
     "etc-group-members": ["wheel", "docker"],

--- a/cloud.ks
+++ b/cloud.ks
@@ -12,7 +12,7 @@ firewall --disabled
 
 bootloader --timeout=1 --append="no_timer_check console=tty1 console=ttyS0,115200n8"
 
-network --bootproto=dhcp --device=eth0 --activate --onboot=on
+network --bootproto=dhcp --onboot=on
 # We use NetworkManager, and Avahi doesn't make much sense in the cloud
 services --disabled=network,avahi-daemon
 services --enabled=NetworkManager,sshd,rsyslog,cloud-init,cloud-init-local,cloud-config,cloud-final


### PR DESCRIPTION
Nothing big here, but we do pick up the `mutate-os-release` change.