### PR TITLE
Revert "treecompose: Use ostree-releng-scripts version of rsync (#185)"

### DIFF
--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -4,7 +4,9 @@ basedir=$(cd $(dirname $0) && pwd)
 . ${basedir}/libtask.sh
 . ${basedir}/libtoolbox.sh
 
-~/ostree-releng-scripts/rsync-repos --rsync-opts="--stats" --src="sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/ostree/" --dest=ostree/
+for v in ostree; do
+    rsync --delete --stats -a sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/ ${v}/
+done
 
 # Update release tags
 ~/ostree-releng-scripts/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
@@ -29,4 +31,6 @@ fi
 # potential changes from anything above.
 ostree --repo=ostree/repo summary -u
 
-~/ostree-releng-scripts/rsync-repos --rsync-opts="--stats" --src="ostree/" --dest="sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/ostree/"
+for v in ostree; do
+    rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
+done


### PR DESCRIPTION
This reverts commit 59514d596787cce25b977025fff2f00b778a88cb.

Sadly the CentOS version of rsync doesn't know about
`--ignore-missing-args`.  The fix will likely be to rework it to use
Fedora or backport rsync or something.