### PR TITLE
exclude 'atomic' from atomic7-testing.repo

### DIFF
--- a/atomic7-testing.repo
+++ b/atomic7-testing.repo
@@ -2,3 +2,4 @@
 name=atomic7-testing
 baseurl=http://cbs.centos.org/repos/atomic7-testing/x86_64/os/
 gpgcheck=0
+exclude=atomic


### PR DESCRIPTION
The compose started pulling `atomic` from `atomic7-testing` which
has an ancient version of the RPM.  We want to test it from git
master, so just exclude it.

FWIW, I didn't test locally, so I'm hoping no other repos take precedence for this RPM.

Fixes #188