### PR TITLE
releases.yml: backtrack alpha to a known working version

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -7,5 +7,5 @@ baseref: "centos-atomic-host/7/x86_64/devel/"
 # Procedure: When performing an update, be sure to change
 # the previous release commit id in run-treecompose too.
 releases:
-  # Version: 7.2016.1026 (2016-11-29 20:25:44)
-  alpha: 5c91fc657de939bca0f594afdf3d5cc915229fb0504905944d739f3be611beb9
+  # Version: 7.2016.1024 (2016-11-29 18:26:12)
+  alpha: c2903d2e61789f8fbe4038fa08897aa1f382743c4f221e91282102a67dcdda68


### PR DESCRIPTION
In light of both the latest alpha and continuous releases having
SELinux issues (see:
https://github.com/CentOS/sig-atomic-buildscripts/issues/191), let's put
alpha to the latest known working release (7.2016.1024 is right before
the sepolicies started regressing).

---

It might look strange for versions to go backwards, but since ostree doesn't care about version strings, it shouldn't cause any upgradability issues.