### PR TITLE
cloud/vagrant: Sync kickstarts with Fedora

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -48,11 +48,6 @@ passwd -l root
 # remove the user anaconda forces us to make
 userdel -r none
 
-# If you want to remove rsyslog and just use journald, remove this!
-echo -n "Disabling persistent journal"
-rmdir /var/log/journal/ 
-echo . 
-
 echo -n "Getty fixes"
 # although we want console output going to the serial console, we don't
 # actually have the opportunity to login there. FIX.

--- a/vagrant.ks
+++ b/vagrant.ks
@@ -1,22 +1,20 @@
-# Like the cloud image, but tuned for vagrant.  Enable
-# the vagrant user, disable cloud-init.
+# Like the Atomic Host cloud image, but tuned for vagrant: enable the
+# vagrant user, disable cloud-init.
 
 %include cloud.ks
 
-services --disabled=cloud-init,cloud-init-local,cloud-config,cloud-final
-
-rootpw vagrant
 user --name=vagrant --password=vagrant
+rootpw vagrant
 
 %post --erroronfail
+
+# Really cloud-init should be disabled by default, and enabled
+# only in the openstack qcow2 and AMI.
+systemctl mask cloud-init cloud-init-local cloud-config cloud-final
 
 # The inherited cloud %post locks the passwd, but we want it
 # unlocked for vagrant, just like downstream.
 passwd -u root
-
-# Work around cloud-init being both disabled and enabled; need
-# to refactor to a common base.
-rm /etc/systemd/system/multi-user.target.wants/cloud-init* /etc/systemd/system/multi-user.target.wants/cloud-config*
 
 # Vagrant setup
 sed -i 's/Defaults\s*requiretty/Defaults !requiretty/' /etc/sudoers


### PR DESCRIPTION
This should fix the `network` service being enabled in the Vagrant box,
otherwise it's mostly reordering and other small tweaks.

See also https://pagure.io/fedora-kickstarts/pull-request/109