### PR TITLE
downstream: Drop mutate-os-release

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -15,7 +15,6 @@
 
     "initramfs-args": ["--no-hostonly", "--add", "iscsi"],
 
-    "mutate-os-release": "7",
     "postprocess-script": "treecompose-post.sh",
 
     "etc-group-members": ["wheel", "docker"],


### PR DESCRIPTION
It doesn't work yet because we don't have the new release package.