### PR TITLE
overlay: Version lock runc with Fedora

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -94,10 +94,7 @@ components:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1288162#c8
   - distgit: xfsprogs
 
-  - src: github:opencontainers/runc
-    tag: v1.0.0-rc1
-    distgit:
-      branch: master
+  - distgit: runc
 
   - distgit: etcd
 


### PR DESCRIPTION
We had a frozen git tag, and at that point we might as well track
Fedora.