### PR TITLE
repos: Ensure we pick up our oci-systemd-hook and oci-register-machine

### DIFF
--- a/CentOS-extras.repo
+++ b/CentOS-extras.repo
@@ -4,6 +4,6 @@ mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras&in
 #baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
 gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
-# List excludes here that have higher versions in extras, until we implement
+# List excludes here that have higher versions due to missing git tags, until we implement
 # priorities: https://github.com/CentOS/sig-atomic-buildscripts/issues/138
-exclude=cloud-utils-growpart atomic skopeo
+exclude=cloud-utils-growpart atomic skopeo oci-register-machine oci-systemd-hook

--- a/virt7-docker-el-candidate.repo
+++ b/virt7-docker-el-candidate.repo
@@ -3,6 +3,5 @@ name=virt7-docker-el-candidate
 baseurl=http://cbs.centos.org/repos/virt7-docker-el-candidate/x86_64/os/
 enabled=0
 gpgcheck=0
-# We want skopeo built from the git repo, so exclude it here and in
-# CentOS-Extras
-exclude=skopeo
+# See CentOS-extras.repo - change that first, then make this match.
+exclude=atomic skopeo oci-register-machine oci-systemd-hook


### PR DESCRIPTION
It was reported to me that we had an old oci-systemd-hook, and
a newer one was desired for system container work.