### PR TITLE
overlay: Nevermind, do manual integration for oci hooks

### DIFF
--- a/CentOS-extras.repo
+++ b/CentOS-extras.repo
@@ -6,4 +6,4 @@ gpgcheck=0
 gpgkey=http://mirror.centos.org/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7
 # List excludes here that have higher versions due to missing git tags, until we implement
 # priorities: https://github.com/CentOS/sig-atomic-buildscripts/issues/138
-exclude=cloud-utils-growpart atomic skopeo oci-register-machine oci-systemd-hook
+exclude=cloud-utils-growpart atomic skopeo

--- a/overlay.yml
+++ b/overlay.yml
@@ -45,14 +45,6 @@ components:
 
   - src: github:projectatomic/atomic-devmode
 
-  - src: github:projectatomic/oci-systemd-hook
-    distgit:
-      branch: master
-
-  - src: github:projectatomic/oci-register-machine
-    distgit:
-      branch: master
-
   - src: distgit
     distgit:
       name: python-ipaddress

--- a/virt7-docker-el-candidate.repo
+++ b/virt7-docker-el-candidate.repo
@@ -4,4 +4,4 @@ baseurl=http://cbs.centos.org/repos/virt7-docker-el-candidate/x86_64/os/
 enabled=0
 gpgcheck=0
 # See CentOS-extras.repo - change that first, then make this match.
-exclude=atomic skopeo oci-register-machine oci-systemd-hook
+exclude=atomic skopeo


### PR DESCRIPTION
It turns out docker has a Requires on oci-register-machine with
an Epoch, which ours doesn't include.  This causes libsolv to
depsolve back to an ancient 1.9 docker without it.

We really need to pull docker fully into rdgo to fix issues like
this.  Alternatively, we could teach rdgo to automatically pull
in the upstream Epoch.

In the meantime, this.