### PR TITLE
releases: Cut a new alpha from 7.2017.6

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -5,5 +5,5 @@
 baseref: "centos-atomic-host/7/x86_64/devel/"
 
 releases:
-  # Version: 7.2017.4 (2017-01-06 17:09:17)
-  alpha: 5d724da9ae10fd584dc2c3c7d5b41fe2a20dc54fe56a44bb362aa72110c67900
+  # Version: 7.2017.6 (2017-01-06 22:07:14)
+  alpha: 020c3cf188e3f493b929fbc107ad15abfb1e5d206b019da230918f850f3ff2e


### PR DESCRIPTION
Fixes `docker run --privileged`.