### PR TITLE
centos-ci: add smoketesting for the continuous branch

### DIFF
--- a/centos-ci/jjb/sig-atomic-defaults.yml
+++ b/centos-ci/jjb/sig-atomic-defaults.yml
@@ -1,6 +1,6 @@
 - defaults:
     name: atomic-defaults
-    node: atomic-sig-ci-slave01 
+    node: atomic-sig-ci-slave01
     quiet-period: 0
     description: |
       <p>See <a href="https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel">https://wiki.centos.org/SpecialInterestGroup/Atomic/Devel</a>
@@ -30,5 +30,3 @@
           basedir: sig-atomic-buildscripts
           branches:
             - master
-
-      

--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -71,6 +71,21 @@
       - timed: "H * * * *"
 
     builders:
+      # this is a hack to allow the smoketest to go back
+      # around and tell do-release-tags what to promote
+      - python: |
+          import os
+          import yaml
+          smoketest = os.path.expanduser('~/smoketested-rev')
+          if not os.path.exists(smoketest):
+            exit(0)
+          with open(smoketest) as f:
+            rev = f.read()
+          with open('sig-atomic-buildscripts/releases.yml') as f:
+            releases = yaml.load(f)
+          releases['releases']['smoketested'] = rev
+          with open('sig-atomic-buildscripts/releases.yml', 'w') as f:
+            f.write(yaml.dump(releases))
       - atomic-duffy-builder:
           task: run-treecompose
 
@@ -79,6 +94,26 @@
           project: 'atomic-installer-centos7'
       - atomic-trigger-on-change:
           project: 'atomic-image-cloud-centos7'
+      - atomic-trigger-on-change:
+          project: 'atomic-tree-smoketest-centos7'
+      - atomic-duffy-publisher
+
+- job:
+    name: atomic-tree-smoketest-centos7
+    defaults: atomic-defaults
+
+    # for now, we are only triggered by atomic-treecompose-centos7
+    # because we don't keep any state of *which* commits we've already
+    # tested and which we haven't
+    builders:
+      - atomic-duffy-builder:
+          task: run-tree-smoketest
+      - shell: cp -f build-logs/smoketested-rev ~
+
+    publishers:
+      # retrigger so we run do-release-tags
+      - atomic-trigger-on-change:
+          project: 'atomic-treecompose-centos7'
       - atomic-duffy-publisher
 
 - job-template:

--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -57,7 +57,7 @@
     builders:
       - atomic-duffy-builder:
           task: run-rdgo-rsync
-            
+
     publishers:
       - atomic-trigger-on-change:
           project: 'atomic-treecompose-centos7'
@@ -73,7 +73,7 @@
     builders:
       - atomic-duffy-builder:
           task: run-treecompose
-            
+
     publishers:
       - atomic-trigger-on-change:
           project: 'atomic-installer-centos7'
@@ -93,9 +93,21 @@
           properties-content: OSTREE_BRANCH={branch}
       - atomic-duffy-builder:
           task: run-{imagetask}
-            
+
     publishers:
       - atomic-duffy-publisher
+
+- project:
+    name: atomic-cahc-imagetasks
+    imagetask:
+      - installer
+      - image-cloud
+      - image-pxelive
+    branch:
+      - continuous
+      - alpha
+    jobs:
+      - atomic-cahc-{imagetask}-{branch}
 
 - job-template:
     name: atomic-dockerimage-{distro}-{distrover}
@@ -150,18 +162,8 @@
       - macro-cciskel-duffy-deallocate
 
 - project:
-    name: atomic-rdgo
-    imagetask:
-      - installer
-      - image-cloud
-      - image-pxelive
-    branch:
-      - continuous
-      - alpha
+    name: atomic-dockerimage
     jobs:
-      - atomic-rdgo-centos7
-      - atomic-treecompose-centos7
-      - atomic-cahc-{imagetask}-{branch}
       - atomic-dockerimage-{distro}-{distrover}:
           distro: centos
           distrover: 7

--- a/centos-ci/libtask.sh
+++ b/centos-ci/libtask.sh
@@ -2,6 +2,7 @@ buildscriptsdir=$(cd ~/sig-atomic-buildscripts && pwd)
 build=centos-continuous
 OSTREE_BRANCH=${OSTREE_BRANCH:-continuous}
 ref=centos-atomic-host/7/x86_64/devel/${OSTREE_BRANCH}
+utils=$buildscriptsdir/centos-ci/utils
 
 prepare_job() {
     export WORKSPACE=$HOME/jobs/${JENKINS_JOB_NAME}

--- a/centos-ci/libtask.sh
+++ b/centos-ci/libtask.sh
@@ -15,14 +15,14 @@ prepare_job() {
     rm ${BUILD_LOGS} -rf
     mkdir ${BUILD_LOGS}
 
-    . ~/rsync-password.sh 
+    . ~/rsync-password.sh
 
     # Ensure we're operating on a clean base
     (cd ${buildscriptsdir} && git clean -dfx && git reset --hard HEAD)
 
     # Work around https://lists.centos.org/pipermail/ci-users/2016-July/000302.html
     for file in config.ini atomic-centos-continuous.repo cahc.tdl cloud.ks vagrant.ks pxelive.ks; do
-	sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' ${buildscriptsdir}/${file}
+        sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' ${buildscriptsdir}/${file}
     done
 
     sed -i -e 's,^ref *=.*,ref = '${ref}',' ${buildscriptsdir}/config.ini

--- a/centos-ci/libtoolbox.sh
+++ b/centos-ci/libtoolbox.sh
@@ -9,7 +9,7 @@ prepare_image_build() {
     cd ${build}
 
     if ! test -d repo; then
-	ostree --repo=repo init --mode=archive-z2
+        ostree --repo=repo init --mode=archive-z2
     fi
     ostree --repo=repo remote delete centos-atomic-continuous || true
     ostree --repo=repo remote add --set=gpg-verify=false centos-atomic-continuous http://artifacts.ci.centos.org/sig-atomic/rdgo/centos-continuous/ostree/repo
@@ -20,14 +20,14 @@ prepare_image_build() {
     version=$(ostree --repo=repo show --print-metadata-key=version ${ref} | sed -e "s,',,g")
 
     if test ${OSTREE_BRANCH} = "continuous"; then
-	imgloc=sig-atomic/${build}/images/${imgtype}
+        imgloc=sig-atomic/${build}/images/${imgtype}
     else
-	imgloc=sig-atomic/${build}/images-${OSTREE_BRANCH}/${imgtype}
+        imgloc=sig-atomic/${build}/images-${OSTREE_BRANCH}/${imgtype}
     fi
 
     if curl -L --head -f http://artifacts.ci.centos.org/${imgloc}/${version}/; then
-	echo "Image ${imgtype} at version ${version} already exists"
-	exit 0
+        echo "Image ${imgtype} at version ${version} already exists"
+        exit 0
     fi
 
     cd images/${imgtype}
@@ -40,4 +40,3 @@ finish_image_build() {
     cd ..
     rsync --delete --delete-after --stats -Hrlpt ${imgtype}/ sig-atomic@artifacts.ci.centos.org::${imgloc}/
 }
-    

--- a/centos-ci/libvm.sh
+++ b/centos-ci/libvm.sh
@@ -1,0 +1,51 @@
+# Based on projectatomic/rpm-ostree libvm.sh
+
+vm_setup() {
+    ip=$1; shift
+    SSH="ssh -o UserKnownHostsFile=/dev/null \
+             -o StrictHostKeyChecking=no \
+             root@$ip"
+}
+
+# run command in vm
+# - $@    command to run
+vm_cmd() {
+  $SSH "$@"
+}
+
+# wait until ssh is available on the vm
+# - $1    timeout in second (optional)
+# - $2    previous bootid (optional)
+vm_ssh_wait() {
+  timeout=${1:-0}; shift
+  old_bootid=${1:-}; shift
+  while [ $timeout -gt 0 ]; do
+    if bootid=$(vm_get_boot_id 2>/dev/null); then
+        if [[ $bootid != $old_bootid ]]; then
+            return 0
+        fi
+    fi
+    if test $(($timeout % 5)) == 0; then
+        echo "Still failed to log into VM, retrying for $timeout seconds"
+    fi
+    timeout=$((timeout - 1))
+    sleep 1
+  done
+  if ! vm_cmd true; then
+     echo "Failed to log into VM, retrying with debug:"
+     $SSH -o LogLevel=debug true || true
+  fi
+  false "Timed out while waiting for SSH."
+}
+
+vm_get_boot_id() {
+  vm_cmd cat /proc/sys/kernel/random/boot_id
+}
+
+# reboot the vm
+vm_reboot() {
+  bootid=$(vm_get_boot_id 2>/dev/null)
+  vm_cmd systemctl reboot || :
+  vm_ssh_wait 120 $bootid
+}
+

--- a/centos-ci/run-rdgo
+++ b/centos-ci/run-rdgo
@@ -8,9 +8,9 @@ cd rdgo
 ln -sf ${buildscriptsdir}/overlay.yml .
 if ! test -d src; then
     rpmdistro-gitoverlay init
-fi    
+fi
 
 # Git fetch all the things
 rpmdistro-gitoverlay resolve --fetch-all
 # Do a build
-rpmdistro-gitoverlay build --touch-if-changed ${BUILD_LOGS}/build.stamp --logdir=${BUILD_LOGS}
+rpmdistro-gitoverlay build --touch-if-changed ${BUILD_LOGS}/changed.stamp --logdir=${BUILD_LOGS}

--- a/centos-ci/run-tree-smoketest
+++ b/centos-ci/run-tree-smoketest
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -xeuo pipefail
+
+basedir=$(cd $(dirname $0) && pwd)
+. ${basedir}/libtask.sh
+. ${basedir}/libvm.sh
+
+# In this workflow, we just assume that there is a new commit to test (we're
+# triggered only when a new tree is composed). Otherwise, we'll have to figure
+# out where to keep some state.
+
+git clone https://github.com/projectatomic/atomic-host-tests
+
+domain=$(uuidgen | cut -f1 -d-)
+qcow2=/var/lib/libvirt/images/$domain.qcow2
+
+# use alpha rather than downstream so we can use:
+# https://github.com/projectatomic/rpm-ostree/pull/555
+# use http rather than https because:
+# https://lists.centos.org/pipermail/ci-users/2016-July/000301.html
+curl -Lo $qcow2.gz \
+    http://artifacts.ci.centos.org/sig-atomic/centos-continuous/images-alpha/cloud/latest/images/centos-atomic-host-7.qcow2.gz
+gunzip $qcow2.gz
+
+$utils/create-vm $domain $qcow2
+ip=$($utils/get-vm-ip $domain)
+vm_setup $ip
+
+# prepare the VM for the improved-sanity-test: deploy HEAD^
+vm_cmd sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' \
+  /etc/ostree/remotes.d/centos-atomic-continuous.conf
+vm_cmd ostree pull --commit-metadata-only --depth=1 \
+    centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
+head=$(vm_cmd ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous)
+oldhead=$(vm_cmd ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous^)
+vm_cmd rpm-ostree rebase centos-atomic-host/7/x86_64/devel/continuous $oldhead
+vm_reboot
+
+export ANSIBLE_HOST_KEY_CHECKING=False
+
+pass=0
+if ansible-playbook -v -i $ip, atomic-host-tests/tests/improved-sanity-test/main.yml; then
+    pass=1
+fi
+
+if [ $pass = 0 ]; then
+    echo "Test failed. See above for output."
+    exit 1
+else
+    echo "Test passed."
+    touch ${BUILD_LOGS}/changed.stamp
+    echo "$head" > ${BUILD_LOGS}/smoketested-rev
+fi

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -18,8 +18,8 @@ fi
 treefile=centos-atomic-host-continuous.json
 # Work around https://lists.centos.org/pipermail/ci-users/2016-July/000302.html
 sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' ${buildscriptsdir}/atomic-centos-continuous.repo
-sudo rpm-ostree compose tree --touch-if-changed=${WORKSPACE}/treecompose.stamp --repo=ostree/repo ${buildscriptsdir}/${treefile}
-if test -f ${WORKSPACE}/treecompose.stamp; then
+sudo rpm-ostree compose tree --touch-if-changed=${BUILD_LOGS}/changed.stamp --repo=ostree/repo ${buildscriptsdir}/${treefile}
+if test -f ${BUILD_LOGS}/changed.stamp; then
     sudo chown -R -h $USER:$USER ostree/repo
     ostree --repo=ostree/repo summary -u
     rpm-ostree db --repo=ostree/repo diff centos-atomic-host/7/x86_64/devel/continuous{^,}

--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -44,6 +44,9 @@
     - PyYAML
     - rpmdistro-gitoverlay
     - libgsystem
+    - genisoimage
+    - ansible
+    - virt-install
 
 - service: name={{ item }} state=started
   with_items:

--- a/centos-ci/utils/create-vm
+++ b/centos-ci/utils/create-vm
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -xeuo pipefail
+
+basedir=$(cd $(dirname $0) && pwd)
+
+domain=$1; shift
+qcow2=$1; shift
+
+iso=/var/lib/libvirt/$domain.cidata.iso
+
+if ! [ -f ~/.ssh/id_rsa ]; then
+    ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
+fi
+
+pubkey=$(cat ~/.ssh/id_rsa.pub)
+
+cat > meta-data << EOF
+instance-id: $domain
+local-hostname: $domain
+EOF
+
+cat > user-data << EOF
+#cloud-config
+disable_root: 0
+
+users:
+  - name: root
+    lock-passwd: false
+    inactive: false
+    system: false
+    ssh-authorized-keys:
+      - "$pubkey"
+EOF
+
+genisoimage -input-charset default -volid cidata -joliet \
+            -rock -output $iso user-data meta-data
+
+virt-install --import --name $domain --os-variant rhel7 --ram 2048 --vcpus 2 \
+             --disk path=$qcow2,format=qcow2,bus=virtio \
+             --disk path=$iso,device=cdrom,readonly=on \
+             --network network=default --noautoconsole
+
+$basedir/sshwait $($basedir/get-vm-ip $domain 60)
+
+# give cloud-init some time to inject ssh creds
+sleep 5

--- a/centos-ci/utils/get-vm-ip
+++ b/centos-ci/utils/get-vm-ip
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+
+import sys
+import time
+import libvirt
+
+# We don't do much error checking here. Just let exceptions
+# rise up and exit non-zero.
+
+domain_name = sys.argv[1]
+
+timeout = 0
+if len(sys.argv) > 2:
+    timeout = int(sys.argv[2])
+
+conn = libvirt.openReadOnly(None)
+domain = conn.lookupByName(domain_name)
+
+addrs = domain.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE)
+while len(addrs) == 0 and timeout > 0:
+    time.sleep(1)
+    timeout -= 1
+    addrs = domain.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE)
+
+# just pick the first addr of the first iface
+iface = addrs.keys()[0]
+print addrs[iface]['addrs'][0]['addr']

--- a/centos-ci/utils/sshwait
+++ b/centos-ci/utils/sshwait
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+# from https://github.com/jlebon/files/blob/master/bin/sshwait
+
+if [ $# -ne 1 ]; then
+	echo "Usage: $0 <hostname>"
+fi
+
+# If it's already open, then just exit quietly
+if echo | nc -w 500ms $1 22 2>&1 | grep -q SSH; then
+	exit 0
+fi
+
+echo -n "Waiting for open SSH port..."
+while true; do
+
+	out=$(echo | nc -w 1 $1 22 2>&1 || :)
+	if grep -q SSH <<< "$out"; then
+		break
+	fi
+
+	echo -n '.'
+
+	if [[ $out == "Ncat: Connection timed out." ]]; then
+		continue
+	fi
+
+	if [[ $out == "Ncat: Connection refused." ]] || \
+	   [[ $out == "Ncat: No route to host." ]] || \
+	   [[ $out == "Ncat: Connection reset by peer." ]]; then
+		sleep 1
+		continue
+	fi
+
+	echo
+	echo -n "Unknown error: "
+	echo "$out"
+	exit 1
+done
+
+echo " done!"


### PR DESCRIPTION
Add a new job, atomic-tree-smoketest-centos7, which runs after every new
tree compose. This job runs the improved sanity test from the
atomic-host-tests suite:

https://github.com/projectatomic/atomic-host-tests/tree/master/tests/improved-sanity-test

If the test passes, we bump the smoketested rev, which is stored on the
slave's home directory, for lack of a better place. Whenever the
treecompose runs, we pick up the rev and insert it in releases.yaml so
that do-release-tags does the needful.

Disclaimer: About 13.8% of this code is untested.

Resolves: https://github.com/CentOS/sig-atomic-buildscripts/issues/227