### PR TITLE
run-tree-smoketest: adjust for builder user

### DIFF
--- a/centos-ci/libvm.sh
+++ b/centos-ci/libvm.sh
@@ -1,5 +1,7 @@
 # Based on projectatomic/rpm-ostree libvm.sh
 
+export LIBVIRT_DEFAULT_URI=qemu:///system
+
 vm_setup() {
     ip=$1; shift
     SSH="ssh -o UserKnownHostsFile=/dev/null \

--- a/centos-ci/run-tree-smoketest
+++ b/centos-ci/run-tree-smoketest
@@ -18,9 +18,9 @@ qcow2=/var/lib/libvirt/images/$domain.qcow2
 # https://github.com/projectatomic/rpm-ostree/pull/555
 # use http rather than https because:
 # https://lists.centos.org/pipermail/ci-users/2016-July/000301.html
-curl -Lo $qcow2.gz \
+sudo curl -Lo $qcow2.gz \
     http://artifacts.ci.centos.org/sig-atomic/centos-continuous/images-alpha/cloud/latest/images/centos-atomic-host-7.qcow2.gz
-gunzip $qcow2.gz
+sudo gunzip $qcow2.gz
 
 $utils/create-vm $domain $qcow2
 ip=$($utils/get-vm-ip $domain)
@@ -39,8 +39,9 @@ vm_reboot
 export ANSIBLE_HOST_KEY_CHECKING=False
 
 pass=0
-if ansible-playbook -v -i $ip, atomic-host-tests/tests/improved-sanity-test/main.yml; then
-    pass=1
+if ansible-playbook -v -i $ip, -u root \
+    atomic-host-tests/tests/improved-sanity-test/main.yml; then
+        pass=1
 fi
 
 if [ $pass = 0 ]; then

--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -60,7 +60,7 @@
     - "config_opts['plugin_conf']['tmpfs_enable'] = True"
     - "config_opts['use_nspawn'] = True"
 
-- user: name={{ item }} groups=mock,wheel
+- user: name={{ item }} groups=mock,wheel,libvirt
   with_items:
     - builder
     - prbuilder

--- a/centos-ci/utils/create-vm
+++ b/centos-ci/utils/create-vm
@@ -32,6 +32,7 @@ users:
       - "$pubkey"
 EOF
 
+sudo \
 genisoimage -input-charset default -volid cidata -joliet \
             -rock -output $iso user-data meta-data
 
@@ -40,7 +41,7 @@ virt-install --import --name $domain --os-variant rhel7 --ram 2048 --vcpus 2 \
              --disk path=$iso,device=cdrom,readonly=on \
              --network network=default --noautoconsole
 
-$basedir/sshwait $($basedir/get-vm-ip $domain 60)
+timeout -s9 2m $basedir/sshwait $($basedir/get-vm-ip $domain 60)
 
 # give cloud-init some time to inject ssh creds
 sleep 5


### PR DESCRIPTION
I had initially tested this as the root user. We need just a few
modifications to make this work for builder.