### PR TITLE
jjb: fix nested build-logs rsync'ing

### DIFF
--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -22,7 +22,7 @@
           if ! ssh -tt builder@${{DUFFY_HOST}} '. task.env && ./sig-atomic-buildscripts/centos-ci/{task}'; then
             build_success=false
           fi
-          rsync -Hrlptv --stats -e ssh builder@${{DUFFY_HOST}}:build-logs $WORKSPACE/build-logs || true
+          rsync -Hrlptv --stats -e ssh builder@${{DUFFY_HOST}}:build-logs/ $WORKSPACE/build-logs || true
           # Exit with code from the build
           if test "${{build_success}}" = "false"; then
             echo 'Build failed, see logs above'; exit 1


### PR DESCRIPTION
This caused anything that relied on atomic-trigger-on-change to never
actually fire.