### PR TITLE
do-release-tags: use the new --autocreate

### DIFF
--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -26,6 +26,7 @@
           if ! ssh -tt builder@${{DUFFY_HOST}} '. task.env && ./sig-atomic-buildscripts/centos-ci/{task}'; then
             build_success=false
           fi
+
           rsync -Hrlptv --stats -e ssh builder@${{DUFFY_HOST}}:build-logs/ $WORKSPACE/build-logs || true
           # Exit with code from the build
           if test "${{build_success}}" = "false"; then

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -9,7 +9,7 @@ for v in ostree; do
 done
 
 # Update release tags
-~/ostree-releng-scripts/do-release-tags --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
+~/ostree-releng-scripts/do-release-tags --autocreate --repo=ostree/repo --releases=${buildscriptsdir}/releases.yml
 # Now, ensure we have a delta from N-1 -> N
 if ostree --repo=ostree/repo rev-parse centos-atomic-host/7/x86_64/devel/alpha^ 2>/dev/null; then
     ostree --repo=ostree/repo static-delta generate -n centos-atomic-host/7/x86_64/devel/alpha


### PR DESCRIPTION
So that it can create the smoketested ref.