### PR TITLE
rdgo setup playbook: fix syntax issue

### DIFF
--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -55,7 +55,7 @@
 
 # nspawn is better, also https://lists.fedoraproject.org/pipermail/buildsys/2015-July/004833.html
 # Also https://bugzilla.redhat.com/show_bug.cgi?id=1328212
-- lineinfile: dest=/etc/mock/site-defaults.cfg "line={{ item }}"
+- lineinfile: dest=/etc/mock/site-defaults.cfg line={{ item }}
   with_items:
     - "config_opts['plugin_conf']['tmpfs_enable'] = True"
     - "config_opts['use_nspawn'] = True"


### PR DESCRIPTION
Jobs are failing because of this syntax issue:

```
{"failed": true, "item": "config_opts['plugin_conf']['tmpfs_enable'] =
True", "msg": "unsupported parameter for module: \"line"}
```

We don't need to quote that argument, ansible will still be able to see
spaces in the `{{ item }}`.

I'm still confused though as to how this wasn't causing issues until
now, seeing as this line has been there for quite a while.