### PR TITLE
revving version number for new release

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -14,7 +14,7 @@
     "documentation": false,
 
     "initramfs-args": ["--no-hostonly", "--add", "iscsi"],
-    "automatic_version_prefix": "7.20170201", 
+    "automatic_version_prefix": "7.20170209", 
     "mutate-os-release": "7", 
     "postprocess-script": "treecompose-post.sh",
 


### PR DESCRIPTION
temporarily necessary due to https://github.com/CentOS/sig-atomic-buildscripts/pull/240#issuecomment-276769236