### PR TITLE
Exclude 'ostree' + 'rpm-ostree' from atomic7-testing repo

### DIFF
--- a/atomic7-testing.repo
+++ b/atomic7-testing.repo
@@ -2,4 +2,4 @@
 name=atomic7-testing
 baseurl=http://cbs.centos.org/repos/atomic7-testing/x86_64/os/
 gpgcheck=0
-exclude=atomic ostree
+exclude=atomic ostree rpm-ostree

--- a/atomic7-testing.repo
+++ b/atomic7-testing.repo
@@ -2,4 +2,4 @@
 name=atomic7-testing
 baseurl=http://cbs.centos.org/repos/atomic7-testing/x86_64/os/
 gpgcheck=0
-exclude=atomic
+exclude=atomic ostree


### PR DESCRIPTION
I realized that we did not encounter ostreedev/ostree#814 on CAHC,
which was odd because we should be building `ostree` from source.  The
latest CAHC composes seem to be pulling `ostree` from the
`atomic7-testing`, so let's just exclude it from the repo.