### PR TITLE
Revert "Freeze rpm-ostree at 7b4134c8e6dc852d3a37fad7f47f33fce9c84bfd…

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -70,8 +70,6 @@ components:
   - distgit: libsolv
 
   - src: github:projectatomic/rpm-ostree
-    # https://github.com/projectatomic/rpm-ostree/issues/862
-    freeze: 7b4134c8e6dc852d3a37fad7f47f33fce9c84bfd
     distgit:
       branch: master
       patches: drop


### PR DESCRIPTION
… (#280)"

This reverts commit d5e70a60f36d29a4178f9fffd974ecb0b685ecef.

See https://github.com/projectatomic/rpm-ostree/issues/862#issuecomment-313452803.