### PR TITLE
 ensure content is usable on mirrors and rsync targets

### DIFF
--- a/build_stage1.sh
+++ b/build_stage1.sh
@@ -73,6 +73,8 @@ rpm-ostree compose --repo=${OstreeRepoDir} tree ${GitDir}/centos-atomic-host.jso
 # deal with https://bugzilla.gnome.org/show_bug.cgi?id=748959
 
 chmod -R a+r /srv/repo/objects
+find /srv/repo/ -type d -exec chmod -R a+x {} \;
+find /srv/repo/ -type f -exec chmod -R a+r {} \;
 
 echo 'Stage-1 done, you can now sign the repo, or just run stage2 '
 


### PR DESCRIPTION
running into issues on mirror.centos.org and msync.centos.org where some content is not usable when downstream mirrors use different uid/ for pull and serve. just making the content public should fix that.