### PR TITLE
overlay: Thaw bubblewrap 🔥

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -38,8 +38,6 @@ components:
     spec: internal
 
   - src: github:projectatomic/bubblewrap
-    # https://github.com/projectatomic/rpm-ostree/issues/855
-    freeze: v0.1.8
     spec: internal
 
   - src: github:projectatomic/atomic-devmode


### PR DESCRIPTION
In projectatomic/bubblewrap#205, the issue that we were seeing with
`bubblewrap` (projectatomic/bubblewrap#101) was fixed.  As such, we
can thaw out `bubblewrap` and continue to track git master.