### PR TITLE
centos-ci: run the smoketest against continuous branch

### DIFF
--- a/centos-ci/run-tree-smoketest
+++ b/centos-ci/run-tree-smoketest
@@ -24,6 +24,11 @@ $utils/create-vm $domain $qcow2
 ip=$($utils/get-vm-ip $domain)
 vm_setup $ip
 
+# use http rather than https (just in case) because:
+# https://lists.centos.org/pipermail/ci-users/2016-July/000301.html
+vm_cmd sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' \
+    /etc/ostree/remotes.d/centos-atomic-continuous.conf
+
 export ANSIBLE_HOST_KEY_CHECKING=False
 
 pass=0

--- a/centos-ci/run-tree-smoketest
+++ b/centos-ci/run-tree-smoketest
@@ -14,27 +14,15 @@ git clone https://github.com/projectatomic/atomic-host-tests
 domain=$(uuidgen | cut -f1 -d-)
 qcow2=/var/lib/libvirt/images/$domain.qcow2
 
-# use alpha rather than downstream so we can use:
-# https://github.com/projectatomic/rpm-ostree/pull/555
 # use http rather than https because:
 # https://lists.centos.org/pipermail/ci-users/2016-July/000301.html
 sudo curl -Lo $qcow2.gz \
-    http://artifacts.ci.centos.org/sig-atomic/centos-continuous/images-alpha/cloud/latest/images/centos-atomic-host-7.qcow2.gz
+    http://artifacts.ci.centos.org/sig-atomic/centos-continuous/images/cloud/latest/images/centos-atomic-host-7.qcow2.gz
 sudo gunzip $qcow2.gz
 
 $utils/create-vm $domain $qcow2
 ip=$($utils/get-vm-ip $domain)
 vm_setup $ip
-
-# prepare the VM for the improved-sanity-test: deploy HEAD^
-vm_cmd sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' \
-  /etc/ostree/remotes.d/centos-atomic-continuous.conf
-vm_cmd ostree pull --commit-metadata-only --depth=1 \
-    centos-atomic-continuous:centos-atomic-host/7/x86_64/devel/continuous
-head=$(vm_cmd ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous)
-oldhead=$(vm_cmd ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous^)
-vm_cmd rpm-ostree rebase centos-atomic-host/7/x86_64/devel/continuous $oldhead
-vm_reboot
 
 export ANSIBLE_HOST_KEY_CHECKING=False
 


### PR DESCRIPTION
We abandoned the `alpha` branch in favor of the `smoketested` branch
(see #270), but the process of running the smoketest has been using
an ancient alpha image for months now.  Building an alpha image
appears to have been broken, so I'm not sure why we continue to try
to test against it.  Additionally, the smoketest has changed
so that we don't need to deploy HEAD-1 before running the test.