### PR TITLE
centos-ci: stop building any alpha artifacts

### DIFF
--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -145,7 +145,6 @@
     branch:
       - continuous
       - smoketested
-      - alpha
     jobs:
       - atomic-cahc-{imagetask}-{branch}
 


### PR DESCRIPTION
The `alpha` branch is just a redirect to `smoketested` (see #270), so
let's stop building any artifacts on the `alpha` branch.