### PR TITLE
centos-ci:  separate 'yum install' operation into two steps

### DIFF
--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -29,8 +29,7 @@
   with_items:
     - https://kojipkgs.fedoraproject.org//packages/python-distro/1.0.1/2.el7/noarch/python2-distro-1.0.1-2.el7.noarch.rpm
 
-# Disable epel testing to work around https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2017-6fb8d59d10
-- yum: name={{ item }} state=latest disablerepo=epel-testing
+- yum: name={{ item }} state=latest disablerepo=atomic7-testing
   with_items:
     - rsync
     - mock
@@ -38,15 +37,18 @@
     - libsolv
     - glib2
     - ostree
-    - rpm-ostree
-    - rpm-ostree-toolbox
     - fedpkg
     - PyYAML
     - rpmdistro-gitoverlay
-    - libgsystem
     - genisoimage
     - ansible
     - virt-install
+
+- yum: name={{ item }} state=latest
+  with_items:
+    - libgsystem
+    - rpm-ostree
+    - rpm-ostree-toolbox
 
 - service: name={{ item }} state=started
   with_items:


### PR DESCRIPTION
The `atomic*` jobs on ci.centos.org have been failing since Sept 1
because the duffy nodes have not been able to be setup successfully.

The failure was happening when trying to install all the required
packages in one shot, which caused a newer version of `librepo` to be
pulled in from the `atomic7-testing` repo.

But `python-librepo` requires an older version, so we just separate
the 'offending' packages (`libgsystem`, `rpm-ostree`,
`rpm-ostree-toolbox`) into a separate operation.