### PR TITLE
Revert "overlay: Drop rpm-ostree temporarily (#301)"

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -64,11 +64,10 @@ components:
   # libdnf needs a newer version than Core
   - distgit: libsolv
 
-  # undo immediately after
-  # - src: github:projectatomic/rpm-ostree
-  #   distgit:
-  #     branch: master
-  #     patches: drop
+  - src: github:projectatomic/rpm-ostree
+    distgit:
+      branch: master
+      patches: drop
 
   - src: github:projectatomic/rpm-ostree-toolbox
     distgit:


### PR DESCRIPTION
This reverts commit 3227febf9980bc5eef387e9a3738b9a0e82accd0.

We should be able to build rpm-ostree now.