### PR TITLE
centos-ci: retain the head commit

### DIFF
--- a/centos-ci/run-tree-smoketest
+++ b/centos-ci/run-tree-smoketest
@@ -28,6 +28,7 @@ vm_setup $ip
 # https://lists.centos.org/pipermail/ci-users/2016-July/000301.html
 vm_cmd sed -i -e 's,https://ci.centos.org/artifacts/,http://artifacts.ci.centos.org/,g' \
     /etc/ostree/remotes.d/centos-atomic-continuous.conf
+head=$(vm_cmd ostree rev-parse centos-atomic-host/7/x86_64/devel/continuous)
 
 export ANSIBLE_HOST_KEY_CHECKING=False
 


### PR DESCRIPTION
In c46bbcf, the `run-tree-smoketest` script was changed to accommodate
the new way of running the a-h-t sanity test.

Unfortunately, this was a bit overzealous, as the HEAD commit is used
later in the script to record which commit was tested.

This change alters the script to pull the commit ID of HEAD, so that
it can be stored again as part of the logs.