### PR TITLE
repos: start using virt7-container-common-candidate

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -5,7 +5,7 @@
     "ref": "centos-atomic-host/7/x86_64/standard",
 
     "repos": ["CentOS-Base", "CentOS-updates", "CentOS-extras",
-	      "virt7-docker-common-candidate", "atomic7-testing",
+              "virt7-container-common-candidate", "atomic7-testing",
               "rhel-atomic-rebuild", "CentOS-CR"],
 
     "selinux": true,

--- a/virt7-container-common-candidate.repo
+++ b/virt7-container-common-candidate.repo
@@ -1,0 +1,7 @@
+[virt7-container-common-candidate]
+name=virt7-container-common-candidate
+baseurl=http://cbs.centos.org/repos/virt7-container-common-candidate/x86_64/os/
+enabled=0
+gpgcheck=0
+# See CentOS-extras.repo - change that first, then make this match.
+#exclude=


### PR DESCRIPTION
While debugging a `docker` issue on CAHC, we were informed that the
`virt7-docker-common-candidate` repo is no longer being used.  The new
repo is `virt7-container-common-candidate`, so we should start using
that.