### PR TITLE
repos: exclude `docker` from `virt7-container-common-candidate`

### DIFF
--- a/virt7-container-common-candidate.repo
+++ b/virt7-container-common-candidate.repo
@@ -4,4 +4,4 @@ baseurl=http://cbs.centos.org/repos/virt7-container-common-candidate/x86_64/os/
 enabled=0
 gpgcheck=0
 # See CentOS-extras.repo - change that first, then make this match.
-#exclude=
+exclude=docker


### PR DESCRIPTION
In #307, we started using the `virt7-container-common-candidate` repo
to pull in a new version of `docker`.  Unfortunately, we've seen some
problems, some of which are affecting our tests:

projectatomic/docker#285
projectatomic/docker#286

Until we get fixes for those issues, let's stop grabbing `docker` from
the `virt7-container-common-candidate`.  This should cause `docker` to
come from the `CentOS-extras` repo.