### PR TITLE
libtoolbox.sh: fix cd to nonexistent dir

### DIFF
--- a/centos-ci/jjb/sig-atomic.yml
+++ b/centos-ci/jjb/sig-atomic.yml
@@ -96,10 +96,6 @@
 
     publishers:
       - atomic-trigger-on-change:
-          project: 'atomic-installer-centos7'
-      - atomic-trigger-on-change:
-          project: 'atomic-image-cloud-centos7'
-      - atomic-trigger-on-change:
           project: 'atomic-tree-smoketest-centos7'
       - atomic-duffy-publisher
 

--- a/centos-ci/libtoolbox.sh
+++ b/centos-ci/libtoolbox.sh
@@ -4,36 +4,39 @@ prepare_image_build() {
     imgtype=$1
 
     if test ${OSTREE_BRANCH} = "continuous"; then
-        buildloc=${build}/images
+        imgdir=images
     else
-        buildloc=${build}/images-${OSTREE_BRANCH}
+        imgdir=images-${OSTREE_BRANCH}
     fi
 
     # sudo since -toolbox might have leftover files as root if interrupted
-    sudo rm ${buildloc} -rf
-    mkdir -p ${buildloc}/${imgtype}
+    sudo rm ${build}/${imgdir} -rf
+    mkdir -p ${build}/${imgdir}/${imgtype}
 
     cd ${build}
 
     if ! test -d repo; then
         ostree --repo=repo init --mode=archive-z2
     fi
-    ostree --repo=repo remote delete centos-atomic-continuous || true
-    ostree --repo=repo remote add --set=gpg-verify=false centos-atomic-continuous http://artifacts.ci.centos.org/sig-atomic/rdgo/centos-continuous/ostree/repo
-    # https://github.com/ostreedev/ostree/issues/407
-    ostree --repo=repo pull --mirror --disable-fsync --disable-static-deltas --depth=0 --commit-metadata-only centos-atomic-continuous ${ref}
+
+    ostree --repo=repo remote delete --if-exists centos-atomic-continuous
+    ostree --repo=repo remote add --no-gpg-verify centos-atomic-continuous \
+      http://artifacts.ci.centos.org/sig-atomic/rdgo/centos-continuous/ostree/repo
+
+    ostree --repo=repo pull --mirror --disable-fsync --depth=0 \
+      --commit-metadata-only centos-atomic-continuous ${ref}
 
     rev=$(ostree --repo=repo rev-parse ${ref})
     version=$(ostree --repo=repo show --print-metadata-key=version ${ref} | sed -e "s,',,g")
 
-    imgloc=sig-atomic/${buildloc}/${imgtype}
+    imgloc=sig-atomic/${build}/${imgdir}/${imgtype}
 
     if curl -L --head -f http://artifacts.ci.centos.org/${imgloc}/${version}/; then
         echo "Image ${imgtype} at version ${version} already exists"
         exit 0
     fi
 
-    cd images/${imgtype}
+    cd ${imgdir}/${imgtype}
 }
 
 finish_image_build() {


### PR DESCRIPTION
This is follow-up to #296. We were doing:

    cd images/${imgtype}

which is OK in the continuous case, but in the smoketested case, the
correct dir is `images-smoketested`. This should hopefully make the
smoketested image builder work again.

Also do a few minor tweaks like using `--if-exists` and dropping the
need to specify `--disable-static-deltas`, which should have been long
fixed.