### PR TITLE
host: Add microcode_ctl

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -74,7 +74,7 @@
                  "shadow-utils", "centos-release-atomic",
                  "atomic",
                  "runc",
-		 "systemd", "kernel", "rpm-ostree-client",
+		             "systemd", "kernel", "microcode_ctl", "rpm-ostree-client",
 		 "dracut-network",
 		 "biosdevname",
 		 "coreutils",


### PR DESCRIPTION
This is necessary for Meltdown+Spectre, and is included in RHEL AH.

Note that this required a patch to `microcode_ctl`:
https://git.centos.org/commit/rpms!microcode_ctl.git/4a0bea212733f7f139c327f7999d24e5eaacfab7