### PR TITLE
Add cockpit-networkmanager to list of installed packages

### DIFF
--- a/centos-atomic-host.json
+++ b/centos-atomic-host.json
@@ -118,6 +118,7 @@
 		 "cockpit-shell",
 		 "cockpit-bridge",
                  "cockpit-docker",
+                 "cockpit-networkmanager",
                  "cockpit-ostree",
 		 "setools-console",
                  "device-mapper-multipath",


### PR DESCRIPTION
Please consider merging this pull request.

The Cockpit Networks plugin appears quite useful. Moreover its addition makes a link from the System plugin work ("Network Traffic").

Fedora Atomic includes cockpit-networkmanager as well, see:
[Bug 1292826 - Include cockpit-ostree and cockpit-networkmanager in Fedora Atomic](https://bugzilla.redhat.com/show_bug.cgi?id=1292826)
