### PR TITLE
overlay: freeze ostree spec file to 5133df

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -59,6 +59,7 @@ components:
   - src: github:ostreedev/ostree
     distgit:
       branch: master
+      freeze: 5133df27463af7aa6523ef26b4ad9d3a6ebdab0b
       patches: drop
 
   # libdnf needs a newer version than Core


### PR DESCRIPTION
It looks like the following commit to the ostree spec file broke CAHC
for us:

https://src.fedoraproject.org/rpms/ostree/c/82d1f941ed1504840a63b5635e1051ccd2774b07?branch=master

The ultimate effect is that while users are able to SSH to a CAHC host
normally, Ansible is unable to operate successfully.  I believe it is
because /tmp has become read-only.