### PR TITLE
overlay: Bump distgit to f28, drop libsolv

### DIFF
--- a/centos-7-and-extras-x86_64.cfg
+++ b/centos-7-and-extras-x86_64.cfg
@@ -45,4 +45,11 @@ failovermethod=priority
 exclude=docker-python python-docker-py
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
 gpgcheck=1
+
+[epel]
+name=Extra Packages for Enterprise Linux 7 - $basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-7
 """

--- a/overlay.yml
+++ b/overlay.yml
@@ -49,3 +49,6 @@ components:
     distgit:
       branch: master
       patches: drop
+    rpmwith:
+      - rust
+    build-network: true

--- a/overlay.yml
+++ b/overlay.yml
@@ -20,7 +20,7 @@ aliases:
 
 distgit:
   prefix: fedorapkgs
-  branch: f24
+  branch: f28
   
 root:
   mock: centos-7-and-extras-$arch.cfg
@@ -44,9 +44,6 @@ components:
 
   # Ensures we're more "self hosting"
   - distgit: nss-altfiles
-
-  # libdnf needs a newer version than Core
-  - distgit: libsolv
 
   - src: github:projectatomic/rpm-ostree
     distgit:


### PR DESCRIPTION
We need a newer distgit to pick up
https://src.fedoraproject.org/rpms/rpm-ostree/c/8e5fd5e7d64c45f36146e13080544e74c02a2612?branch=master

However libsolv now needs ninja which we don't have.  Since the version
that's in 7.5 is new enough let's drop it again.