### PR TITLE
cloud: Bump libvirt memory to 3G

### DIFF
--- a/centos-ci/run-image-cloud
+++ b/centos-ci/run-image-cloud
@@ -11,6 +11,10 @@ copy_ppms() {
 }
 trap copy_ppms ERR
 
+# override oz config to at least 3G
+# FIXME - this should probably be an rpm-ostree-toolbox setting
+sudo sed -i 's/memory = .*/memory = 3072/' /etc/oz/oz.cfg
+
 # FIXME - use ISO content rather than KS
 sudo rpm-ostree-toolbox imagefactory ${toolbox_base_args} -i kvm -i vagrant-libvirt -i vagrant-virtualbox --preserve-ks-url \
      --tdl ${buildscriptsdir}/cahc.tdl \


### PR DESCRIPTION
We're hitting issues right now with the installer erroring out. To rule
out whether this is an `ENOSPC` issue, let's try bumping the installer
memory to 3G. If that works, then we can change this override in
rpm-ostree-toolbox (which currently forces it to 2G if it was less), or
make it configurable.