### PR TITLE
treecompose-post.sh: disable firewalld in tree

### DIFF
--- a/treecompose-post.sh
+++ b/treecompose-post.sh
@@ -68,3 +68,7 @@ set -x
 
 cp -f /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
 build-locale-archive
+
+# Disable firewalld - we include it but don't want it enabled by default
+# See https://pagure.io/atomic-wg/issue/372
+systemctl disable firewalld


### PR DESCRIPTION
Follow in the footsteps of Fedora on this[1] and disable in the tree so
that upgrades to the tree don't suddenly have it enabled. But one can
enable it manually if wanted.

[1] https://pagure.io/atomic-wg/issue/372

Closes: #342