### PR TITLE
cloud.ks: Remove rsyslog

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -15,7 +15,7 @@ bootloader --timeout=1 --append="no_timer_check console=tty1 console=ttyS0,11520
 network --bootproto=dhcp --onboot=on
 # We use NetworkManager, and Avahi doesn't make much sense in the cloud
 services --disabled=network,avahi-daemon
-services --enabled=NetworkManager,sshd,rsyslog,cloud-init,cloud-init-local,cloud-config,cloud-final
+services --enabled=NetworkManager,sshd,cloud-init,cloud-init-local,cloud-config,cloud-final
 
 zerombr
 clearpart --all


### PR DESCRIPTION
I was using the Fedora Anaconda to try to install CentOSAH, and
it fell over on this.  It turns out Anaconda in RHEL7 land completely
ignores nonexistent services, but newer versions correctly error.

I think we initially considered shipping rsyslog, then ended up
trying to make it a container before system containers existed.
Anyways, now package layering exists.