### PR TITLE
rdgo: Use assembler container

### DIFF
--- a/centos-ci/libtask.sh
+++ b/centos-ci/libtask.sh
@@ -3,6 +3,7 @@ build=centos-continuous
 OSTREE_BRANCH=${OSTREE_BRANCH:-continuous}
 ref=centos-atomic-host/7/x86_64/devel/${OSTREE_BRANCH}
 utils=$buildscriptsdir/centos-ci/utils
+assembler=quay.io/cgwalters/coreos-assembler
 
 prepare_job() {
     export WORKSPACE=$HOME/jobs/${JENKINS_JOB_NAME}
@@ -27,6 +28,11 @@ prepare_job() {
     grep '^ref =' ${buildscriptsdir}/config.ini
 
     cd ${WORKSPACE}
+}
+
+run_assembler() {
+    sudo docker pull ${assembler}
+    sudo docker run --rm --privileged -v ${buildscriptsdir}:/srv/src -v ${WORKSPACE}:/srv/tmp -v $(cd ~ && pwd):/srv/home -v $(pwd):/srv/build -w /srv/build ${assembler} "$@"
 }
 
 # Avoid recursion

--- a/centos-ci/run-rdgo
+++ b/centos-ci/run-rdgo
@@ -5,12 +5,14 @@ basedir=$(cd $(dirname $0) && pwd)
 . ${basedir}/libtask.sh
 
 cd rdgo
-ln -sf ${buildscriptsdir}/overlay.yml .
+# Note this needs to point inside the container paths
+ln -sf /srv/src/overlay.yml .
 if ! test -d src; then
-    rpmdistro-gitoverlay init
+    run_assembler rpmdistro-gitoverlay init
 fi
 
 # Git fetch all the things
-rpmdistro-gitoverlay resolve --fetch-all
+run_assembler ls -al
+run_assembler rpmdistro-gitoverlay resolve --fetch-all
 # Do a build
-rpmdistro-gitoverlay build --touch-if-changed ${BUILD_LOGS}/changed.stamp --logdir=${BUILD_LOGS}
+run_assembler rpmdistro-gitoverlay build --touch-if-changed /srv/tmp/changed.stamp --logdir=/srv/home/build-logs

--- a/centos-ci/setup/roles/rdgo-system/tasks/main.yml
+++ b/centos-ci/setup/roles/rdgo-system/tasks/main.yml
@@ -39,7 +39,6 @@
     - ostree
     - fedpkg
     - PyYAML
-    - rpmdistro-gitoverlay
     - genisoimage
     - ansible
     - virt-install


### PR DESCRIPTION
We need to do this because Python 3.  One step for making this
pipeline more like FAHC.