### PR TITLE
ci/libtask: Sync with FAHC

### DIFF
--- a/centos-ci/libtask.sh
+++ b/centos-ci/libtask.sh
@@ -7,14 +7,14 @@ assembler=quay.io/cgwalters/coreos-assembler
 
 prepare_job() {
     export WORKSPACE=$HOME/jobs/${JENKINS_JOB_NAME}
-    rm ${WORKSPACE} -rf
+    sudo rm ${WORKSPACE} -rf
     mkdir -p ${WORKSPACE}
 
     export CACHEDIR=$HOME/cache
     mkdir -p ${CACHEDIR}
 
     export BUILD_LOGS=$HOME/build-logs
-    rm ${BUILD_LOGS} -rf
+    sudo rm ${BUILD_LOGS} -rf
     mkdir ${BUILD_LOGS}
 
     . ~/rsync-password.sh


### PR DESCRIPTION
Should fix perm errors.