### PR TITLE
ci: Make sure to chown before syncing out

### DIFF
--- a/centos-ci/run-rdgo-rsync
+++ b/centos-ci/run-rdgo-rsync
@@ -14,6 +14,7 @@ if ${basedir}/run-rdgo; then
 fi
 
 for v in rdgo; do
+    sudo chown -R -h $USER:$USER ${v}/
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done
 

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -36,5 +36,6 @@ fi
 ostree --repo=ostree/repo summary -u
 
 for v in ostree; do
+    sudo chown -R -h $USER:$USER ${v}/
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done


### PR DESCRIPTION
Make sure all the artifacts we sync out are owned by the `sig-atomic`
user.