### PR TITLE
ci: Make all artifact directories accessible to nginx

### DIFF
--- a/centos-ci/run-rdgo-rsync
+++ b/centos-ci/run-rdgo-rsync
@@ -15,6 +15,7 @@ fi
 
 for v in rdgo; do
     sudo chown -R -h $USER:$USER ${v}/
+    find ${v}/ -type d -exec chmod a+rX {} +
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done
 

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -37,5 +37,6 @@ ostree --repo=ostree/repo summary -u
 
 for v in ostree; do
     sudo chown -R -h $USER:$USER ${v}/
+    find ${v}/ -type d -exec chmod a+rX {} +
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done


### PR DESCRIPTION
E.g. otherwise `rdgo/build/repodata/` is not visible.