### PR TITLE
libtask: sync with FAHC

### DIFF
--- a/centos-ci/libtask.sh
+++ b/centos-ci/libtask.sh
@@ -3,7 +3,7 @@ build=centos-continuous
 OSTREE_BRANCH=${OSTREE_BRANCH:-continuous}
 ref=centos-atomic-host/7/x86_64/devel/${OSTREE_BRANCH}
 utils=$buildscriptsdir/centos-ci/utils
-assembler=quay.io/cgwalters/coreos-assembler
+assembler=quay.io/cgwalters/coreos-assembler:alpha
 
 prepare_job() {
     export WORKSPACE=$HOME/jobs/${JENKINS_JOB_NAME}
@@ -32,7 +32,7 @@ prepare_job() {
 
 run_assembler() {
     sudo docker pull ${assembler}
-    sudo docker run --rm --privileged -v ${buildscriptsdir}:/srv/src -v ${WORKSPACE}:/srv/tmp -v $(cd ~ && pwd):/srv/home -v $(pwd):/srv/build -w /srv/build ${assembler} "$@"
+    sudo docker run --user root:root --rm  --entrypoint '' --privileged -v ${buildscriptsdir}:/srv/src -v ${WORKSPACE}:/srv/tmp -v $(cd ~ && pwd):/srv/home -v $(pwd):/srv/build -w /srv/build ${assembler} "$@"
 }
 
 # Avoid recursion


### PR DESCRIPTION
Freeze on coreos-assembler:alpha tag and sync `run_assembler` command
with FAHC. Notably, the `--entrypoint ''` arg.