### PR TITLE
ci: Don't chmod symlinks

### DIFF
--- a/centos-ci/run-rdgo-rsync
+++ b/centos-ci/run-rdgo-rsync
@@ -15,7 +15,7 @@ fi
 
 for v in rdgo; do
     sudo chown -R -h $USER:$USER ${v}/
-    find ${v}/ -exec chmod a+rX {} +
+    find ${v}/ ! -type l -exec chmod a+rX {} +
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done
 

--- a/centos-ci/run-treecompose
+++ b/centos-ci/run-treecompose
@@ -37,6 +37,6 @@ ostree --repo=ostree/repo summary -u
 
 for v in ostree; do
     sudo chown -R -h $USER:$USER ${v}/
-    find ${v}/ -exec chmod a+rX {} +
+    find ${v}/ ! -type l -exec chmod a+rX {} +
     rsync --delete --stats -a ${v}/ sig-atomic@artifacts.ci.centos.org::sig-atomic/${build}/${v}/
 done


### PR DESCRIPTION
Either the symlink is broken and `chmod` will complain, or the symlink
works and points to within the root dir passed to `find` and so will be
caught anyway. (This then makes sure we also don't somehow `chmod` a
target outside the root dir we care about).