### PR TITLE
Revert "overlay.yml: Freeze ostree to prevent Ignition regression"

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -38,8 +38,6 @@ components:
   - src: github:projectatomic/atomic-devmode
 
   - src: github:ostreedev/ostree
-    # https://github.com/dustymabe/ignition-dracut/pull/26
-    freeze: 1db0db3d7aa98e3db98ba93f7fc2e17305f95007
     distgit:
       branch: master
       patches: drop


### PR DESCRIPTION
Updated Ignition with the right ordering is now in COPR.

This reverts commit 70c3b844c90fb56199212927baf362772518759f.