### PR TITLE
alt script to fetch signed repo 

### DIFF
--- a/fetch_signed_repo.sh
+++ b/fetch_signed_repo.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+
+## Run the script from /srv (or other HomeDir, if you change the value
+## below) like so:
+##
+## bash sig-atomic-buildscripts/build_ostree_components.sh /srv/builddir
+## 
+## Other files to edit/check:
+##
+## atomic-7.1.tdl must point to an install tree avail over http,
+## there's a hard-coded IP address there now
+## 
+## atomic-7.1-cloud.ks and atomic-7.1-vagrant.ks must point to
+## the desired ostree repo in line beginning w/ "ostreesetup"
+
+VERSION=7.$( date  +%Y%m%d )
+
+DateStamp=$( date  +%Y%m%d_%H%M%S )
+BuildDir=$1
+LogFile=${BuildDir}/log
+mkdir -p ${BuildDir}
+# Make it absolute
+BuildDir=$(cd $BuildDir && pwd)
+GitDir=${BuildDir}/sig-atomic-buildscripts
+OstreeRepoDir=/srv/repo && mkdir -p $OstreeRepoDir
+ln -s ${OstreeRepoDir} ${BuildDir}/repo
+
+set -x
+set -e
+set -o pipefail
+
+## update script from git, commented out for now
+cd ${BuildDir}
+git clone https://github.com/CentOS/sig-atomic-buildscripts && cd sig-atomic-buildscripts && git checkout downstream
+cd ${BuildDir}
+
+# Init, make sure we have the bits we need installed. 
+cp -f ${GitDir}/rhel-atomic-rebuild.repo /etc/yum.repos.d/
+yum -y install ostree rpm-ostree glib2 docker libvirt epel-release libgsystem
+
+
+if [ -f ${GitDir}/atomic7-testing.repo ]; then
+   mv ${GitDir}/atomic7-testing.repo /etc/yum.repos.d/
+fi
+
+echo 'enabled=0' >> /etc/yum.repos.d/atomic7-testing.repo
+yum --enablerepo=atomic7-testing -y install rpm-ostree-toolbox
+
+service firewalld stop
+
+
+## backup the last built repo, commented out for now
+
+#  XXX: We need to only retain the last 14 builds or so, Todo, add a find + rm for older tree's
+#/bin/rsync -Ha --stats /srv/rolling/ /srv/rolling.${DateStamp} > ${LogFile} 2>&1
+#echo '----------' >> ${LogFile}
+
+## create repo in BuildDir, this will fail w/o issue if already exists
+
+if ! test -d ${BuildDir}/repo/objects; then
+    ostree --repo=${BuildDir}/repo init --mode=archive-z2
+fi
+
+# sync repo from buildlogs server, where signed tree is composed nightly
+
+ostree remote add --repo=/srv/repo centos-atomic-host --set=gpg-verify=true https://buildlogs.centos.org/centos/7/atomic/x86_64/repo && ostree pull --depth=1 --repo=/srv/repo --mirror centos-atomic-host centos-atomic-host/7/x86_64/standard
+
+# deal with https://bugzilla.gnome.org/show_bug.cgi?id=748959
+
+chmod -R a+r /srv/repo/objects
+find /srv/repo/ -type d -exec chmod -R a+x {} \;
+find /srv/repo/ -type f -exec chmod -R a+r {} \;
+
+echo 'Stage-1 done, you can now sign the repo, or just run stage2 '
+


### PR DESCRIPTION
There's a nightly job that composes and signs a tree and places it in https://buildlogs.centos.org/centos/7/atomic/x86_64/repo/. This script grabs that tree for use in image building, rather than composing a fresh, unsigned tree. 