### PR TITLE
specify lorax_rootfs_size

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -15,6 +15,8 @@ ref         = %(os_name)s/%(release)s/%(arch)s/%(tree_name)s
 
 lorax_exclude_packages = oscap-anaconda-addon
 
+lorax_rootfs_size = 3
+
 # Base repository
 yum_baseurl = http://mirror.centos.org/centos/%(release)s/os/%(arch)s/
 


### PR DESCRIPTION
larger rootfs to address image build failures
see https://bugzilla.redhat.com/show_bug.cgi?id=1715116