### PR TITLE
fix rpm-ostree-toolbox dep

### DIFF
--- a/atomic7-testing.repo
+++ b/atomic7-testing.repo
@@ -1,4 +1,5 @@
 [atomic7-testing]
 name=atomic7-testing
-baseurl=http://cbs.centos.org/repos/atomic7-testing/x86_64/os/
+#baseurl=http://cbs.centos.org/repos/atomic7-testing/x86_64/os/
+baseurl=https://download.copr.fedorainfracloud.org/results/jasonbrooks/rpm-ostree-toolbox/epel-7-x86_64
 gpgcheck=0


### PR DESCRIPTION
due to https://lists.centos.org/pipermail/centos-devel/2020-March/036679.html
replacing this package with package built in copr from same sources